### PR TITLE
Roll deps: stockparfait v0.0.8

### DIFF
--- a/distribution/distribution.go
+++ b/distribution/distribution.go
@@ -77,7 +77,7 @@ func (d *Distribution) Run(ctx context.Context, cfg config.ExperimentConfig) err
 	}
 	d.context = ctx
 	d.histogram = stats.NewHistogram(&d.config.Buckets)
-	tickers, err := d.config.Reader.Tickers()
+	tickers, err := d.config.Reader.Tickers(ctx)
 	if err != nil {
 		return errors.Annotate(err, "failed to list tickers")
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/stockparfait/errors v0.0.4
 	github.com/stockparfait/logging v0.0.4
 	github.com/stockparfait/parallel v0.0.2
-	github.com/stockparfait/stockparfait v0.0.7
+	github.com/stockparfait/stockparfait v0.0.8
 	github.com/stockparfait/testutil v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/stockparfait/logging v0.0.4 h1:ds+sVkyJP5mE0PjEeHBN9+gMHx67XduL0Xg/yk
 github.com/stockparfait/logging v0.0.4/go.mod h1:wLrsscPazhCAjC/sGmqSA+GghnWUwiSDT/kDwxC0XEI=
 github.com/stockparfait/parallel v0.0.2 h1:EjACOojMU6UZ2yxJNRPhQRFByoFICiobNThKo4CX6l8=
 github.com/stockparfait/parallel v0.0.2/go.mod h1:tbZ3EkWvXo9qbqC2UHr6FynuIaRL9vSBARqFHug7hxA=
-github.com/stockparfait/stockparfait v0.0.7 h1:EpJQaOSLncIY3c7+xjG3un04jRSF0eVo/qoCCpN4BLE=
-github.com/stockparfait/stockparfait v0.0.7/go.mod h1:doDcKD9L1e+jXM1RNBQcQhHt5QUpqtI+5FOdkx4JE04=
+github.com/stockparfait/stockparfait v0.0.8 h1:KffjYm3ESBS0tKlVU6QgIfYS6fDWC8BxRa6cBmokz3o=
+github.com/stockparfait/stockparfait v0.0.8/go.mod h1:doDcKD9L1e+jXM1RNBQcQhHt5QUpqtI+5FOdkx4JE04=
 github.com/stockparfait/testutil v0.0.1 h1:Qq4RzSl+pA0y+3Jr1fF9CbjTJBwHOWZy8c4RLomHVpc=
 github.com/stockparfait/testutil v0.0.1/go.mod h1:Tr0oAxbuEQ+XjD0BlQLG2wkKDhE2EotCuPAchxH6zew=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This adds the ability to filter tickers by average daily cash volume, volatility, and average yearly growth.

Part of #11 .