### PR TITLE
Distribution: more flexible config options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -121,12 +121,13 @@ type Distribution struct {
 	Buckets          stats.Buckets           `json:"buckets"`
 	UseMeans         bool                    `json:"use means"`  // use bucket means rather than middles
 	KeepZeros        bool                    `json:"keep zeros"` // by default, skip y==0 points
-	Graph            string                  `json:"graph" required:"true"`
+	DistGraph        string                  `json:"distribution graph"`
 	ChartType        string                  `json:"chart type" choices:"line,bars" default:"line"`
 	SamplesGraph     string                  `json:"samples graph"`
 	SamplesRightAxis bool                    `json:"samples right axis"`
 	Normalize        bool                    `json:"normalize" default:"true"`
 	RefDist          *AnalyticalDistribution `json:"reference distribution"`
+	RefGraph         string                  `json:"reference graph"`
 	AdjustRef        bool                    `json:"adjust reference distribution"`
 	BatchSize        int                     `json:"batch size" default:"10"` // must be >0
 	Workers          int                     `json:"parallel workers"`        // >0; default = 2*runtime.NumCPU()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,7 @@ func TestConfig(t *testing.T) {
     {"hold": {"data": {"DB": "test"}}},
     {"distribution": {
       "data": {"DB": "test"},
-      "graph": "dist",
+      "distribution graph": "dist",
       "parallel workers": 1
     }}
   ]
@@ -124,7 +124,7 @@ func TestConfig(t *testing.T) {
 					{Config: &Distribution{
 						Reader:    &defaultReader,
 						Buckets:   defaultBuckets,
-						Graph:     "dist",
+						DistGraph: "dist",
 						ChartType: "line",
 						Normalize: true,
 						BatchSize: 10,

--- a/distribution/distribution_test.go
+++ b/distribution/distribution_test.go
@@ -82,7 +82,7 @@ func TestDistribution(t *testing.T) {
 			var cfg config.Distribution
 			So(cfg.InitMessage(testutil.JSON(fmt.Sprintf(`{
   "data": {"DB path": "%s", "DB": "%s"},
-  "graph": "g"
+  "distribution graph": "g"
 }`, tmpdir, dbName))), ShouldBeNil)
 			var dist Distribution
 			So(dist.Run(ctx, &cfg), ShouldBeNil)
@@ -101,10 +101,11 @@ func TestDistribution(t *testing.T) {
   "data": {"DB path": "%s", "DB": "%s"},
   "buckets": {"n": 3, "minval": -0.4, "maxval": 0.4},
   "use means": true,
-  "graph": "g",
+  "distribution graph": "g",
   "chart type": "bars",
   "normalize": false,
   "samples graph": "sg",
+  "reference graph": "g",
   "reference distribution": {"name": "t"}
 }`, tmpdir, dbName))), ShouldBeNil)
 			var dist Distribution


### PR DESCRIPTION
Separate graph IDs for the sample distribution and the reference distribution.
Also, allow skipping the sample distribution graph, to plot only the reference distribution or the sample counts.
Skip a warning log for missing prices - they may be missing due to date range.

Part of #11.