### PR TITLE
Distribution: add a compounding option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,6 +167,9 @@ func (e *Distribution) InitMessage(js interface{}) error {
 	if err := message.Init(e, js); err != nil {
 		return errors.Annotate(err, "failed to init Distribution")
 	}
+	if e.Compound < 1 {
+		return errors.Reason("compound = %d must be >= 1", e.Compound)
+	}
 	if e.BatchSize <= 0 {
 		return errors.Reason("batch size = %d must be positive", e.BatchSize)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,7 @@ type Distribution struct {
 	LogProfits *DistributionPlot `json:"log-profits"`
 	Means      *DistributionPlot `json:"means"`
 	MADs       *DistributionPlot `json:"MADs"`
+	Compound   int               `json:"compound" default:"1"`    // log-profit step size; must be >= 1
 	BatchSize  int               `json:"batch size" default:"10"` // must be >0
 	Workers    int               `json:"parallel workers"`        // >0; default = 2*runtime.NumCPU()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -157,6 +157,7 @@ func TestConfig(t *testing.T) {
 							ChartType: "line",
 							Normalize: true,
 						},
+						Compound:  1,
 						BatchSize: 10,
 						Workers:   1,
 					}},

--- a/distribution/assets/Distribution-all-stocks-with-samples.json
+++ b/distribution/assets/Distribution-all-stocks-with-samples.json
@@ -64,7 +64,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Accumulated Distribution",
+          "title": "Normalized Accumulated Distribution",
           "y_log_scale": false
         },
         {

--- a/distribution/assets/GOOG-vs-TSLA-normalized.json
+++ b/distribution/assets/GOOG-vs-TSLA-normalized.json
@@ -66,7 +66,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Distribution",
+          "title": "Normalized Distribution",
           "y_log_scale": false
         }
       ],

--- a/distribution/assets/Vol-1M-stocks.json
+++ b/distribution/assets/Vol-1M-stocks.json
@@ -70,7 +70,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Accumulated Distribution",
+          "title": "Normalized Accumulated Distribution",
           "y_log_scale": false
         },
         {

--- a/distribution/assets/all-stocks-normal.json
+++ b/distribution/assets/all-stocks-normal.json
@@ -39,7 +39,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Accumulated Distribution",
+          "title": "Normalized Accumulated Distribution",
           "y_log_scale": false
         }
       ],

--- a/distribution/assets/by-sectors.json
+++ b/distribution/assets/by-sectors.json
@@ -373,7 +373,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Accumulated Distribution",
+          "title": "Normalized Accumulated Distribution",
           "y_log_scale": false
         }
       ],

--- a/distribution/assets/by-volume.json
+++ b/distribution/assets/by-volume.json
@@ -103,7 +103,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Accumulated Distribution",
+          "title": "Normalized Accumulated Distribution",
           "y_log_scale": false
         }
       ],

--- a/distribution/assets/by-years.json
+++ b/distribution/assets/by-years.json
@@ -130,7 +130,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Accumulated Distribution",
+          "title": "Normalized Accumulated Distribution",
           "y_log_scale": false
         }
       ],

--- a/distribution/assets/means-mads.json
+++ b/distribution/assets/means-mads.json
@@ -61,7 +61,7 @@
       "graphs": [
         {
           "id": "dist",
-          "title": "Noramlized Accumulated Distribution",
+          "title": "Normalized Accumulated Distribution",
           "y_log_scale": false
         }
       ],

--- a/distribution/distribution.go
+++ b/distribution/distribution.go
@@ -309,7 +309,7 @@ func (d *Distribution) processTicker(ticker string, res *jobResult) error {
 		return nil
 	}
 	ts := stats.NewTimeseries().FromPrices(rows, stats.PriceFullyAdjusted)
-	sample := ts.LogProfits()
+	sample := ts.LogProfits(d.config.Compound)
 	res.Means = append(res.Means, sample.Mean())
 	res.MADs = append(res.MADs, sample.MAD())
 	if res.Histogram != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/stockparfait/errors v0.0.4
 	github.com/stockparfait/logging v0.0.4
 	github.com/stockparfait/parallel v0.0.2
-	github.com/stockparfait/stockparfait v0.0.10
+	github.com/stockparfait/stockparfait v0.1.0
 	github.com/stockparfait/testutil v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/stockparfait/logging v0.0.4 h1:ds+sVkyJP5mE0PjEeHBN9+gMHx67XduL0Xg/yk
 github.com/stockparfait/logging v0.0.4/go.mod h1:wLrsscPazhCAjC/sGmqSA+GghnWUwiSDT/kDwxC0XEI=
 github.com/stockparfait/parallel v0.0.2 h1:EjACOojMU6UZ2yxJNRPhQRFByoFICiobNThKo4CX6l8=
 github.com/stockparfait/parallel v0.0.2/go.mod h1:tbZ3EkWvXo9qbqC2UHr6FynuIaRL9vSBARqFHug7hxA=
-github.com/stockparfait/stockparfait v0.0.10 h1:XjsagHbt8mYfbs1LzcsJXgPEADsSAQIoKdXet6T5f+o=
-github.com/stockparfait/stockparfait v0.0.10/go.mod h1:doDcKD9L1e+jXM1RNBQcQhHt5QUpqtI+5FOdkx4JE04=
+github.com/stockparfait/stockparfait v0.1.0 h1:GCpScMbYC9ZYQYcXkRjKA0kQzP8GV16Jy5dN1rMSMYw=
+github.com/stockparfait/stockparfait v0.1.0/go.mod h1:doDcKD9L1e+jXM1RNBQcQhHt5QUpqtI+5FOdkx4JE04=
 github.com/stockparfait/testutil v0.0.1 h1:Qq4RzSl+pA0y+3Jr1fF9CbjTJBwHOWZy8c4RLomHVpc=
 github.com/stockparfait/testutil v0.0.1/go.mod h1:Tr0oAxbuEQ+XjD0BlQLG2wkKDhE2EotCuPAchxH6zew=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This allows plotting a distribution of log-profits for longer intervals.

Also, fix typos in *.json configs.

Part of #11.