### PR TITLE
Refactor: move PlotDistribution out of distribution experiment

### DIFF
--- a/distribution/distribution.go
+++ b/distribution/distribution.go
@@ -18,14 +18,12 @@ package distribution
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/stockparfait/errors"
 	"github.com/stockparfait/experiments"
 	"github.com/stockparfait/experiments/config"
 	"github.com/stockparfait/logging"
 	"github.com/stockparfait/parallel"
-	"github.com/stockparfait/stockparfait/plot"
 	"github.com/stockparfait/stockparfait/stats"
 )
 
@@ -44,203 +42,12 @@ type Distribution struct {
 var _ experiments.Experiment = &Distribution{}
 var _ parallel.JobsIter = &Distribution{}
 
-// maybeSkipZeros removes (x, y) elements where y < 1e-300, if so configured.
-// Strictly speaking, we're trying to avoid zeros, but in practice anything
-// below this number may be printed or interpreted as 0 in plots.
-func maybeSkipZeros(xs, ys []float64, c *config.DistributionPlot) ([]float64, []float64) {
-	if len(xs) != len(ys) {
-		panic(errors.Reason("len(xs) [%d] != len(ys) [%d]", len(xs), len(ys)))
-	}
-	if c.KeepZeros {
-		return xs, ys
-	}
-	xs1 := []float64{}
-	ys1 := []float64{}
-	for i, x := range xs {
-		if ys[i] >= 1.0e-300 {
-			xs1 = append(xs1, x)
-			ys1 = append(ys1, ys[i])
-		}
-	}
-	return xs1, ys1
-}
-
 // prefix the experiment's ID to s, if there is one.
 func (d *Distribution) prefix(s string) string {
 	if d.config.ID == "" {
 		return s
 	}
 	return d.config.ID + " " + s
-}
-
-// maybeLog10 computes log10 for the slice of values if LogPDF is true.
-func maybeLog10(ys []float64, c *config.DistributionPlot) []float64 {
-	if !c.LogY {
-		return ys
-	}
-	res := make([]float64, len(ys))
-	for i, y := range ys {
-		res[i] = math.Log10(y)
-	}
-	return res
-}
-
-// filterXY optionally skips zeros, computes log10 if configured, and stores the
-// Y range for vertical lines.
-func filterXY(xs, ys []float64, c *config.DistributionPlot) ([]float64, []float64) {
-	xs, ys = maybeSkipZeros(xs, ys, c)
-	ys = maybeLog10(ys, c)
-	return xs, ys
-}
-
-// minMax returns the min and max values from ys.
-func minMax(ys []float64) (float64, float64) {
-	min := math.Inf(1)
-	max := math.Inf(-1)
-	for _, y := range ys {
-		if y < min {
-			min = y
-		}
-		if y > max {
-			max = y
-		}
-	}
-	return min, max
-}
-
-func plotDistribution(ctx context.Context, h *stats.Histogram, c *config.DistributionPlot, legend string) error {
-	if c == nil {
-		return nil
-	}
-	var xs []float64
-	var ys []float64
-	yLabel := "p.d.f."
-
-	if c.UseMeans {
-		xs = h.Xs()
-	} else {
-		xs = h.Buckets().Xs(0.5)
-	}
-
-	if c.RawCounts {
-		yLabel = "counts"
-		ys = make([]float64, len(h.Counts()))
-		for i, c := range h.Counts() {
-			ys[i] = float64(c)
-		}
-	} else {
-		ys = h.PDFs()
-	}
-	xs, ys = filterXY(xs, ys, c)
-	min, max := minMax(ys)
-	plt, err := plot.NewXYPlot(xs, ys)
-	if err != nil {
-		return errors.Annotate(err, "failed to create plot '%s'", legend)
-	}
-	plt.SetLegend(legend + " " + yLabel)
-	if c.LogY {
-		yLabel = "log10(" + yLabel + ")"
-	}
-	plt.SetYLabel(yLabel)
-	if c.ChartType == "bars" {
-		plt.SetChartType(plot.ChartBars)
-	}
-	plt.SetLeftAxis(c.LeftAxis)
-	if err := plot.Add(ctx, plt, c.Graph); err != nil {
-		return errors.Annotate(err, "failed to add plot '%s'", legend)
-	}
-	if c.PlotMean {
-		if err := plotMean(ctx, h, c.Graph, min, max, legend); err != nil {
-			return errors.Annotate(err, "failed to plot '%s mean'", legend)
-		}
-	}
-	if err := plotPercentiles(ctx, h, c, min, max, legend); err != nil {
-		return errors.Annotate(err, "failed to plot '%s percentiles'", legend)
-	}
-	if err := plotAnalytical(ctx, h, c, legend); err != nil {
-		return errors.Annotate(err, "failed to plot '%s ref dist'", legend)
-	}
-	return nil
-}
-
-func plotMean(ctx context.Context, h *stats.Histogram, graph string, min, max float64, legend string) error {
-	x := h.Mean()
-	plt, err := plot.NewXYPlot([]float64{x, x}, []float64{min, max})
-	if err != nil {
-		return errors.Annotate(err, "failed to create plot '%s mean'", legend)
-	}
-	plt.SetLegend(fmt.Sprintf("%s mean=%.4g", legend, x))
-	plt.SetYLabel("").SetChartType(plot.ChartDashed)
-	if err := plot.Add(ctx, plt, graph); err != nil {
-		return errors.Annotate(err, "failed to add '%s mean' plot", legend)
-	}
-	return nil
-}
-
-func plotPercentiles(ctx context.Context, h *stats.Histogram, c *config.DistributionPlot, min, max float64, legend string) error {
-	for _, p := range c.Percentiles {
-		x := h.Quantile(p / 100.0)
-		plt, err := plot.NewXYPlot([]float64{x, x}, []float64{min, max})
-		if err != nil {
-			return errors.Annotate(err, "failed to create plot '%s %gth %%-ile'",
-				legend, p)
-		}
-		plt.SetLegend(fmt.Sprintf("%s %gth %%-ile=%.3g", legend, p, x))
-		plt.SetYLabel("").SetChartType(plot.ChartDashed)
-		if err := plot.Add(ctx, plt, c.Graph); err != nil {
-			return errors.Annotate(err, "failed to add plot '%s %gth %%-ile'", legend, p)
-		}
-	}
-	return nil
-}
-
-func plotAnalytical(ctx context.Context, h *stats.Histogram, c *config.DistributionPlot, legend string) error {
-	if c.RefDist == nil {
-		return nil
-	}
-	mean := c.RefDist.Mean
-	mad := c.RefDist.MAD
-	if c.AdjustRef {
-		mean = h.Mean()
-		mad = h.MAD()
-	}
-	var dist stats.Distribution
-	distName := ""
-	switch c.RefDist.Name {
-	case "t":
-		dist = stats.NewStudentsTDistribution(c.RefDist.Alpha, mean, mad)
-		distName = fmt.Sprintf("T distribution a=%.2f", c.RefDist.Alpha)
-	case "normal":
-		dist = stats.NewNormalDistribution(mean, mad)
-		distName = "Normal distribution"
-	default:
-		return errors.Reason("unsuppoted distribution type: '%s'", c.RefDist.Name)
-	}
-	var xs []float64
-	if c.UseMeans {
-		xs = h.Xs()
-	} else {
-		xs = h.Buckets().Xs(0.5)
-	}
-	ys := make([]float64, len(xs))
-	for i, x := range xs {
-		ys[i] = dist.Prob(x)
-	}
-	xs, ys = filterXY(xs, ys, c)
-	plt, err := plot.NewXYPlot(xs, ys)
-	if err != nil {
-		return errors.Annotate(err, "failed to create '%s' analytical plot", legend)
-	}
-	plt.SetLegend(legend + " " + distName).SetChartType(plot.ChartDashed)
-	if c.LogY {
-		plt.SetYLabel("log10(p.d.f.)")
-	} else {
-		plt.SetYLabel("p.d.f.")
-	}
-	if err := plot.Add(ctx, plt, c.Graph); err != nil {
-		return errors.Annotate(err, "failed to add '%s' analytical plot", legend)
-	}
-	return nil
 }
 
 func (d *Distribution) Run(ctx context.Context, cfg config.ExperimentConfig) error {
@@ -270,13 +77,13 @@ func (d *Distribution) Run(ctx context.Context, cfg config.ExperimentConfig) err
 	if d.histogram.Size() == 0 {
 		return nil
 	}
-	if err := plotDistribution(ctx, d.histogram, d.config.LogProfits, d.prefix("log-profit")); err != nil {
+	if err := experiments.PlotDistribution(ctx, d.histogram, d.config.LogProfits, d.prefix("log-profit")); err != nil {
 		return errors.Annotate(err, "failed to plot '%s' sample distribution", d.config.ID)
 	}
-	if err := plotDistribution(ctx, d.meansHistogram, d.config.Means, d.prefix("means")); err != nil {
+	if err := experiments.PlotDistribution(ctx, d.meansHistogram, d.config.Means, d.prefix("means")); err != nil {
 		return errors.Annotate(err, "failed to plot '%s' means distribution", d.config.ID)
 	}
-	if err := plotDistribution(ctx, d.madsHistogram, d.config.MADs, d.prefix("MADs")); err != nil {
+	if err := experiments.PlotDistribution(ctx, d.madsHistogram, d.config.MADs, d.prefix("MADs")); err != nil {
 		return errors.Annotate(err, "failed to plot '%s' MADs distribution", d.config.ID)
 	}
 	if d.meansHistogram != nil {

--- a/experiments.go
+++ b/experiments.go
@@ -17,10 +17,12 @@ package experiments
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/stockparfait/errors"
 	"github.com/stockparfait/experiments/config"
 	"github.com/stockparfait/stockparfait/plot"
+	"github.com/stockparfait/stockparfait/stats"
 )
 
 type contextKey int
@@ -64,6 +66,197 @@ func AddValue(ctx context.Context, key, value string) error {
 // save data in files.
 type Experiment interface {
 	Run(ctx context.Context, cfg config.ExperimentConfig) error
+}
+
+// maybeSkipZeros removes (x, y) elements where y < 1e-300, if so configured.
+// Strictly speaking, we're trying to avoid zeros, but in practice anything
+// below this number may be printed or interpreted as 0 in plots.
+func maybeSkipZeros(xs, ys []float64, c *config.DistributionPlot) ([]float64, []float64) {
+	if len(xs) != len(ys) {
+		panic(errors.Reason("len(xs) [%d] != len(ys) [%d]", len(xs), len(ys)))
+	}
+	if c.KeepZeros {
+		return xs, ys
+	}
+	xs1 := []float64{}
+	ys1 := []float64{}
+	for i, x := range xs {
+		if ys[i] >= 1.0e-300 {
+			xs1 = append(xs1, x)
+			ys1 = append(ys1, ys[i])
+		}
+	}
+	return xs1, ys1
+}
+
+// maybeLog10 computes log10 for the slice of values if LogPDF is true.
+func maybeLog10(ys []float64, c *config.DistributionPlot) []float64 {
+	if !c.LogY {
+		return ys
+	}
+	res := make([]float64, len(ys))
+	for i, y := range ys {
+		res[i] = math.Log10(y)
+	}
+	return res
+}
+
+// filterXY optionally skips zeros, computes log10 if configured, and stores the
+// Y range for vertical lines.
+func filterXY(xs, ys []float64, c *config.DistributionPlot) ([]float64, []float64) {
+	xs, ys = maybeSkipZeros(xs, ys, c)
+	ys = maybeLog10(ys, c)
+	return xs, ys
+}
+
+// minMax returns the min and max values from ys.
+func minMax(ys []float64) (float64, float64) {
+	min := math.Inf(1)
+	max := math.Inf(-1)
+	for _, y := range ys {
+		if y < min {
+			min = y
+		}
+		if y > max {
+			max = y
+		}
+	}
+	return min, max
+}
+
+func PlotDistribution(ctx context.Context, h *stats.Histogram, c *config.DistributionPlot, legend string) error {
+	if c == nil {
+		return nil
+	}
+	var xs []float64
+	var ys []float64
+	yLabel := "p.d.f."
+
+	if c.UseMeans {
+		xs = h.Xs()
+	} else {
+		xs = h.Buckets().Xs(0.5)
+	}
+
+	if c.RawCounts {
+		yLabel = "counts"
+		ys = make([]float64, len(h.Counts()))
+		for i, c := range h.Counts() {
+			ys[i] = float64(c)
+		}
+	} else {
+		ys = h.PDFs()
+	}
+	xs, ys = filterXY(xs, ys, c)
+	min, max := minMax(ys)
+	plt, err := plot.NewXYPlot(xs, ys)
+	if err != nil {
+		return errors.Annotate(err, "failed to create plot '%s'", legend)
+	}
+	plt.SetLegend(legend + " " + yLabel)
+	if c.LogY {
+		yLabel = "log10(" + yLabel + ")"
+	}
+	plt.SetYLabel(yLabel)
+	if c.ChartType == "bars" {
+		plt.SetChartType(plot.ChartBars)
+	}
+	plt.SetLeftAxis(c.LeftAxis)
+	if err := plot.Add(ctx, plt, c.Graph); err != nil {
+		return errors.Annotate(err, "failed to add plot '%s'", legend)
+	}
+	if c.PlotMean {
+		if err := plotMean(ctx, h, c.Graph, min, max, legend); err != nil {
+			return errors.Annotate(err, "failed to plot '%s mean'", legend)
+		}
+	}
+	if err := plotPercentiles(ctx, h, c, min, max, legend); err != nil {
+		return errors.Annotate(err, "failed to plot '%s percentiles'", legend)
+	}
+	if err := plotAnalytical(ctx, h, c, legend); err != nil {
+		return errors.Annotate(err, "failed to plot '%s ref dist'", legend)
+	}
+	return nil
+}
+
+func plotMean(ctx context.Context, h *stats.Histogram, graph string, min, max float64, legend string) error {
+	x := h.Mean()
+	plt, err := plot.NewXYPlot([]float64{x, x}, []float64{min, max})
+	if err != nil {
+		return errors.Annotate(err, "failed to create plot '%s mean'", legend)
+	}
+	plt.SetLegend(fmt.Sprintf("%s mean=%.4g", legend, x))
+	plt.SetYLabel("").SetChartType(plot.ChartDashed)
+	if err := plot.Add(ctx, plt, graph); err != nil {
+		return errors.Annotate(err, "failed to add '%s mean' plot", legend)
+	}
+	return nil
+}
+
+func plotPercentiles(ctx context.Context, h *stats.Histogram, c *config.DistributionPlot, min, max float64, legend string) error {
+	for _, p := range c.Percentiles {
+		x := h.Quantile(p / 100.0)
+		plt, err := plot.NewXYPlot([]float64{x, x}, []float64{min, max})
+		if err != nil {
+			return errors.Annotate(err, "failed to create plot '%s %gth %%-ile'",
+				legend, p)
+		}
+		plt.SetLegend(fmt.Sprintf("%s %gth %%-ile=%.3g", legend, p, x))
+		plt.SetYLabel("").SetChartType(plot.ChartDashed)
+		if err := plot.Add(ctx, plt, c.Graph); err != nil {
+			return errors.Annotate(err, "failed to add plot '%s %gth %%-ile'", legend, p)
+		}
+	}
+	return nil
+}
+
+func plotAnalytical(ctx context.Context, h *stats.Histogram, c *config.DistributionPlot, legend string) error {
+	if c.RefDist == nil {
+		return nil
+	}
+	mean := c.RefDist.Mean
+	mad := c.RefDist.MAD
+	if c.AdjustRef {
+		mean = h.Mean()
+		mad = h.MAD()
+	}
+	var dist stats.Distribution
+	distName := ""
+	switch c.RefDist.Name {
+	case "t":
+		dist = stats.NewStudentsTDistribution(c.RefDist.Alpha, mean, mad)
+		distName = fmt.Sprintf("T distribution a=%.2f", c.RefDist.Alpha)
+	case "normal":
+		dist = stats.NewNormalDistribution(mean, mad)
+		distName = "Normal distribution"
+	default:
+		return errors.Reason("unsuppoted distribution type: '%s'", c.RefDist.Name)
+	}
+	var xs []float64
+	if c.UseMeans {
+		xs = h.Xs()
+	} else {
+		xs = h.Buckets().Xs(0.5)
+	}
+	ys := make([]float64, len(xs))
+	for i, x := range xs {
+		ys[i] = dist.Prob(x)
+	}
+	xs, ys = filterXY(xs, ys, c)
+	plt, err := plot.NewXYPlot(xs, ys)
+	if err != nil {
+		return errors.Annotate(err, "failed to create '%s' analytical plot", legend)
+	}
+	plt.SetLegend(legend + " " + distName).SetChartType(plot.ChartDashed)
+	if c.LogY {
+		plt.SetYLabel("log10(p.d.f.)")
+	} else {
+		plt.SetYLabel("p.d.f.")
+	}
+	if err := plot.Add(ctx, plt, c.Graph); err != nil {
+		return errors.Annotate(err, "failed to add '%s' analytical plot", legend)
+	}
+	return nil
 }
 
 // TestExperiment is a fake experiment used in tests. Define actual experiments

--- a/experiments.go
+++ b/experiments.go
@@ -89,7 +89,7 @@ func maybeSkipZeros(xs, ys []float64, c *config.DistributionPlot) ([]float64, []
 	return xs1, ys1
 }
 
-// maybeLog10 computes log10 for the slice of values if LogPDF is true.
+// maybeLog10 computes log10 for the slice of values if LogY is true.
 func maybeLog10(ys []float64, c *config.DistributionPlot) []float64 {
 	if !c.LogY {
 		return ys
@@ -101,8 +101,7 @@ func maybeLog10(ys []float64, c *config.DistributionPlot) []float64 {
 	return res
 }
 
-// filterXY optionally skips zeros, computes log10 if configured, and stores the
-// Y range for vertical lines.
+// filterXY optionally skips zeros and computes log10 if configured.
 func filterXY(xs, ys []float64, c *config.DistributionPlot) ([]float64, []float64) {
 	xs, ys = maybeSkipZeros(xs, ys, c)
 	ys = maybeLog10(ys, c)

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -16,6 +16,7 @@ package experiments
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stockparfait/experiments/config"
@@ -36,7 +37,7 @@ func TestExperiments(t *testing.T) {
 		ctx = plot.Use(ctx, canvas)
 		ctx = UseValues(ctx, values)
 
-		_, err := plot.EnsureGraph(ctx, plot.KindXY, "main", "top")
+		g, err := plot.EnsureGraph(ctx, plot.KindXY, "main", "top")
 		So(err, ShouldBeNil)
 
 		Convey("PlotDistribution works", func() {
@@ -45,7 +46,7 @@ func TestExperiments(t *testing.T) {
 			js := testutil.JSON(`
 {
     "graph": "main",
-    "buckets": {"n": 3, "minval": -5, "maxval": 5},
+    "buckets": {"n": 9, "minval": -5, "maxval": 5},
     "normalize": false,
     "use means": true,
     "raw counts": true,
@@ -57,8 +58,12 @@ func TestExperiments(t *testing.T) {
 }`)
 			So(cfg.InitMessage(js), ShouldBeNil)
 			h := stats.NewHistogram(&cfg.Buckets)
-			h.Add(2.0, 3.0, 3.0, 4.0)
+			h.Add(-2.0, -0.5, 0.5, 2.0)
 			So(PlotDistribution(ctx, h, &cfg, "test"), ShouldBeNil)
+			So(len(g.Plots), ShouldEqual, 4)
+			So(g.Plots[0].Legend, ShouldEqual, "test counts")
+			So(g.Plots[0].X, ShouldResemble, []float64{-2, 0, 2})
+			So(g.Plots[0].Y, ShouldResemble, []float64{0, math.Log10(2), 0})
 		})
 
 		Convey("for TestExperiment", func() {

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stockparfait/experiments/config"
 	"github.com/stockparfait/stockparfait/plot"
+	"github.com/stockparfait/stockparfait/stats"
+	"github.com/stockparfait/testutil"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -36,6 +38,28 @@ func TestExperiments(t *testing.T) {
 
 		_, err := plot.EnsureGraph(ctx, plot.KindXY, "main", "top")
 		So(err, ShouldBeNil)
+
+		Convey("PlotDistribution works", func() {
+			So(err, ShouldBeNil)
+			var cfg config.DistributionPlot
+			js := testutil.JSON(`
+{
+    "graph": "main",
+    "buckets": {"n": 3, "minval": -5, "maxval": 5},
+    "normalize": false,
+    "use means": true,
+    "raw counts": true,
+    "log Y": true,
+    "chart type": "bars",
+    "plot mean": true,
+    "percentiles": [50],
+    "reference distribution": {"name": "t"}
+}`)
+			So(cfg.InitMessage(js), ShouldBeNil)
+			h := stats.NewHistogram(&cfg.Buckets)
+			h.Add(2.0, 3.0, 3.0, 4.0)
+			So(PlotDistribution(ctx, h, &cfg, "test"), ShouldBeNil)
+		})
 
 		Convey("for TestExperiment", func() {
 			conf := config.TestExperimentConfig{


### PR DESCRIPTION
It is a more gerenally useful function that can now be used in other experiments.

Part of #33.