### PR TITLE
Plot counts in the same DistributionPlot

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -143,21 +143,22 @@ func (f *FindMin) InitMessage(js interface{}) error {
 // DistributionPlot is a config for a single graph in the Distribution
 // experiment.
 type DistributionPlot struct {
-	Graph        string                  `json:"graph" required:"true"`
-	Buckets      stats.Buckets           `json:"buckets"`
-	ChartType    string                  `json:"chart type" choices:"line,bars" default:"line"`
-	Normalize    bool                    `json:"normalize"`  // to mean=0, MAD=1
-	UseMeans     bool                    `json:"use means"`  // use bucket means rather than middles
-	KeepZeros    bool                    `json:"keep zeros"` // by default, skip y==0 points
-	LogY         bool                    `json:"log Y"`      // plot log10(y)
-	LeftAxis     bool                    `json:"left axis"`
-	RawCounts    bool                    `json:"raw counts"` // plot raw counts
-	RefDist      *AnalyticalDistribution `json:"reference distribution"`
-	AdjustRef    bool                    `json:"adjust reference distribution"`
-	DeriveAlpha  *FindMin                `json:"derive alpha"`  // for ref. dist. from data
-	IgnoreCounts int                     `json:"ignore counts"` // when deriving alpha
-	PlotMean     bool                    `json:"plot mean"`
-	Percentiles  []float64               `json:"percentiles"` // in [0..100]
+	Graph          string                  `json:"graph" required:"true"`
+	CountsGraph    string                  `json:"counts graph"` // plot buckets' counts
+	Buckets        stats.Buckets           `json:"buckets"`
+	ChartType      string                  `json:"chart type" choices:"line,bars" default:"line"`
+	Normalize      bool                    `json:"normalize"`  // to mean=0, MAD=1
+	UseMeans       bool                    `json:"use means"`  // use bucket means rather than middles
+	KeepZeros      bool                    `json:"keep zeros"` // by default, skip y==0 points
+	LogY           bool                    `json:"log Y"`      // plot log10(y)
+	LeftAxis       bool                    `json:"left axis"`
+	CountsLeftAxis bool                    `json:"counts left axis"`
+	RefDist        *AnalyticalDistribution `json:"reference distribution"`
+	AdjustRef      bool                    `json:"adjust reference distribution"`
+	DeriveAlpha    *FindMin                `json:"derive alpha"`  // for ref. dist. from data
+	IgnoreCounts   int                     `json:"ignore counts"` // when deriving alpha
+	PlotMean       bool                    `json:"plot mean"`
+	Percentiles    []float64               `json:"percentiles"` // in [0..100]
 }
 
 var _ message.Message = &DistributionPlot{}

--- a/distribution/assets/Distribution-all-stocks-with-samples.json
+++ b/distribution/assets/Distribution-all-stocks-with-samples.json
@@ -20,6 +20,7 @@
             "n": 201,
             "spacing": "symmetric exponential"
           },
+          "counts graph": "counts",
           "graph": "dist",
           "log Y": true,
           "normalize": true,
@@ -27,33 +28,6 @@
             "alpha": 3.0,
             "name": "t"
           },
-          "use means": true
-        }
-      }
-    },
-    {
-      "distribution": {
-        "data": {
-          "DB": "sharadar",
-          "sources": ["SEP"],
-          "end": "2022-07-31",
-          "exclude tickers": [
-            "JWACU",
-            "BOALY"
-          ],
-          "start": "1998-01-01"
-        },
-        "id": "all stocks 1998-2022 raw",
-        "log-profits": {
-          "buckets": {
-            "maxval": 700,
-            "minval": 0.2,
-            "n": 201,
-            "spacing": "symmetric exponential"
-          },
-          "graph": "counts",
-          "normalize": true,
-          "raw counts": true,
           "use means": true
         }
       }

--- a/distribution/assets/GOOG-exp-buckets.json
+++ b/distribution/assets/GOOG-exp-buckets.json
@@ -23,37 +23,9 @@
             "n": 101,
             "spacing": "symmetric exponential"
           },
+          "counts graph": "counts",
           "graph": "dist",
           "log Y": true,
-          "use means": true
-        }
-      }
-    },
-    {
-      "distribution": {
-        "data": {
-          "DB": "sharadar",
-          "sources": ["SEP"],
-          "end": "2022-07-31",
-          "exclude tickers": [
-            "JWACU",
-            "BOALY"
-          ],
-          "start": "1998-01-01",
-          "tickers": [
-            "GOOG"
-          ]
-        },
-        "id": "GOOG raw",
-        "log-profits": {
-          "buckets": {
-            "maxval": 0.2,
-            "minval": 0.005,
-            "n": 101,
-            "spacing": "symmetric exponential"
-          },
-          "graph": "counts",
-          "raw counts": true,
           "use means": true
         }
       }

--- a/distribution/assets/GOOG-linear-buckets.json
+++ b/distribution/assets/GOOG-linear-buckets.json
@@ -23,36 +23,8 @@
             "n": 101
           },
           "chart type": "bars",
+          "counts graph": "counts",
           "graph": "dist",
-          "use means": true
-        }
-      }
-    },
-    {
-      "distribution": {
-        "data": {
-          "DB": "sharadar",
-          "sources": ["SEP"],
-          "end": "2022-07-31",
-          "exclude tickers": [
-            "JWACU",
-            "BOALY"
-          ],
-          "start": "1998-01-01",
-          "tickers": [
-            "GOOG"
-          ]
-        },
-        "id": "GOOG raw",
-        "log-profits": {
-          "buckets": {
-            "maxval": 0.2,
-            "minval": -0.2,
-            "n": 101
-          },
-          "chart type": "bars",
-          "graph": "counts",
-          "raw counts": true,
           "use means": true
         }
       }

--- a/distribution/assets/Vol-1M-stocks.json
+++ b/distribution/assets/Vol-1M-stocks.json
@@ -23,6 +23,7 @@
             "n": 201,
             "spacing": "symmetric exponential"
           },
+          "counts graph": "counts",
           "graph": "dist",
           "log Y": true,
           "normalize": true,
@@ -30,36 +31,6 @@
             "alpha": 3.0,
             "name": "t"
           },
-          "use means": true
-        }
-      }
-    },
-    {
-      "distribution": {
-        "data": {
-          "DB": "sharadar",
-          "sources": ["SEP"],
-          "cash volume": {
-            "min": 1000000
-          },
-          "end": "2022-07-31",
-          "exclude tickers": [
-            "JWACU",
-            "BOALY"
-          ],
-          "start": "1998-01-01"
-        },
-        "id": "Vol > $1M, 1998-2022 raw",
-        "log-profits": {
-          "buckets": {
-            "maxval": 200,
-            "minval": 0.2,
-            "n": 201,
-            "spacing": "symmetric exponential"
-          },
-          "graph": "counts",
-          "normalize": true,
-          "raw counts": true,
           "use means": true
         }
       }

--- a/distribution/distribution_test.go
+++ b/distribution/distribution_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"testing"
 
@@ -99,10 +98,10 @@ func TestDistribution(t *testing.T) {
   "data": {"DB path": "%s", "DB": "%s"},
   "log-profits": {
     "graph": "g",
+    "counts graph": "g",
     "buckets": {"n": 3, "minval": -0.4, "maxval": 0.4},
     "normalize": false,
     "use means": true,
-    "raw counts": true,
     "log Y": true,
     "chart type": "bars",
     "plot mean": true,
@@ -120,11 +119,10 @@ func TestDistribution(t *testing.T) {
 				"test average MAD":  "0.1347",
 				"test average mean": "0.04766",
 			})
-			So(len(g.Plots), ShouldEqual, 7)
-			So(g.Plots[0].Legend, ShouldEqual, "test log-profit counts")
+			So(len(g.Plots), ShouldEqual, 8)
+			So(g.Plots[1].Legend, ShouldEqual, "test log-profit counts")
 			// The first value is skipped due to 0 count.
-			logCount := math.Log10(2)
-			So(g.Plots[0].Y, ShouldResemble, []float64{logCount, logCount})
+			So(g.Plots[1].Y, ShouldResemble, []float64{2, 2})
 		})
 	})
 }

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -16,7 +16,6 @@ package experiments
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	"github.com/stockparfait/experiments/config"
@@ -60,6 +59,8 @@ func TestExperiments(t *testing.T) {
 
 		g, err := plot.EnsureGraph(ctx, plot.KindXY, "main", "top")
 		So(err, ShouldBeNil)
+		cg, err := plot.EnsureGraph(ctx, plot.KindXY, "counts", "top")
+		So(err, ShouldBeNil)
 
 		Convey("PlotDistribution works", func() {
 			So(err, ShouldBeNil)
@@ -67,10 +68,10 @@ func TestExperiments(t *testing.T) {
 			js := testutil.JSON(`
 {
     "graph": "main",
+    "counts graph": "counts",
     "buckets": {"n": 9, "minval": -5, "maxval": 5},
     "normalize": false,
     "use means": true,
-    "raw counts": true,
     "log Y": true,
     "chart type": "bars",
     "plot mean": true,
@@ -87,9 +88,12 @@ func TestExperiments(t *testing.T) {
 			h.Add(-2.0, -0.5, 0.5, 2.0)
 			So(PlotDistribution(ctx, h, &cfg, "test"), ShouldBeNil)
 			So(len(g.Plots), ShouldEqual, 4)
-			So(g.Plots[0].Legend, ShouldEqual, "test counts")
-			So(g.Plots[0].X, ShouldResemble, []float64{-2, 0, 2})
-			So(g.Plots[0].Y, ShouldResemble, []float64{0, math.Log10(2), 0})
+			So(len(cg.Plots), ShouldEqual, 1)
+			So(g.Plots[0].Legend, ShouldEqual, "test p.d.f.")
+			So(cg.Plots[0].Legend, ShouldEqual, "test counts")
+			So(cg.Plots[0].YLabel, ShouldEqual, "counts")
+			So(cg.Plots[0].X, ShouldResemble, []float64{-2, 0, 2})
+			So(cg.Plots[0].Y, ShouldResemble, []float64{1, 2, 1})
 		})
 
 		Convey("for TestExperiment", func() {


### PR DESCRIPTION
Rather than using two instances of `DistributionPlot` for p.d.f. and counts, allow the same `DistributionPlot` to plot both. In particular, this reuses the same histogram built in the `distribution` experiment, speeding it up.

Part of #33.