### PR TITLE
Use config.DeriveAlpha instead of FindMin

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -280,7 +280,7 @@ type PowerDist struct {
 	MADDist   *DistributionPlot `json:"MAD distribution"`
 	SigmaDist *DistributionPlot `json:"sigma distribution"`
 	AlphaDist *DistributionPlot `json:"alpha distribution"`
-	// Defaults to alpha \in [1.01..100], e=0.01, max. iter=1000.
+	// Default: alpha \in [1.01..100], e=0.01, max. iter=1000, ignore counts=10.
 	AlphaParams *DeriveAlpha `json:"alpha params"`
 	StatSamples int          `json:"statistic samples" default:"10000"` // >= 3
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,11 +174,12 @@ func TestConfig(t *testing.T) {
 								Samples:  1000,
 								Buckets:  defaultBuckets,
 							},
-							DeriveAlpha: &FindMin{
+							DeriveAlpha: &DeriveAlpha{
 								MinX:          2.0,
 								MaxX:          4.0,
 								Epsilon:       0.01,
 								MaxIterations: 1000,
+								IgnoreCounts:  10,
 							},
 						},
 						Compound:  1,
@@ -200,11 +201,12 @@ func TestConfig(t *testing.T) {
 							Samples: 10000,
 							Points:  200,
 						},
-						AlphaParams: &FindMin{
+						AlphaParams: &DeriveAlpha{
 							MinX:          1.01,
 							MaxX:          100.0,
 							Epsilon:       0.01,
 							MaxIterations: 1000,
+							IgnoreCounts:  10,
 						},
 						CumulSamples: 10000,
 						StatSamples:  10000,

--- a/experiments.go
+++ b/experiments.go
@@ -301,10 +301,10 @@ func AnalyticalDistribution(ctx context.Context, c *config.AnalyticalDistributio
 // DeriveAlpha estimates the degrees of freedom parameter for a Student's T
 // distribution with the given mean and MAD that most closely corresponds to the
 // sample distribution given as a histogram h.
-func DeriveAlpha(h *stats.Histogram, mean, MAD float64, c *config.FindMin, ignoreCounts int) float64 {
+func DeriveAlpha(h *stats.Histogram, mean, MAD float64, c *config.DeriveAlpha) float64 {
 	f := func(alpha float64) float64 {
 		d := stats.NewStudentsTDistribution(alpha, mean, MAD)
-		return DistributionDistance(h, d, ignoreCounts)
+		return DistributionDistance(h, d, c.IgnoreCounts)
 	}
 	return FindMin(f, c.MinX, c.MaxX, c.Epsilon, c.MaxIterations)
 }
@@ -325,7 +325,7 @@ func plotAnalytical(ctx context.Context, h *stats.Histogram, c *config.Distribut
 		xs = h.Buckets().Xs(0.5)
 	}
 	if c.DeriveAlpha != nil {
-		dc.Alpha = DeriveAlpha(h, dc.Mean, dc.MAD, c.DeriveAlpha, c.IgnoreCounts)
+		dc.Alpha = DeriveAlpha(h, dc.Mean, dc.MAD, c.DeriveAlpha)
 		if err := AddValue(ctx, legend+" alpha", fmt.Sprintf("%.4g", dc.Alpha)); err != nil {
 			return errors.Annotate(err, "failed to add value for '%s alpha'", legend)
 		}

--- a/powerdist/powerdist.go
+++ b/powerdist/powerdist.go
@@ -96,9 +96,8 @@ func (d *PowerDist) Run(ctx context.Context, cfg config.ExperimentConfig) error 
 		// Add an extra function closure to cache and hide these vars.
 		mean := d.source.Mean()
 		mad := d.source.MAD()
-		k := d.config.AlphaIgnoreCounts
 		return func(h *stats.Histogram) float64 {
-			return experiments.DeriveAlpha(h, mean, mad, d.config.AlphaParams, k)
+			return experiments.DeriveAlpha(h, mean, mad, d.config.AlphaParams)
 		}
 	}
 	if err := d.plotStatistic(ctx, d.config.AlphaDist, alphaFn(), "Alphas"); err != nil {
@@ -138,7 +137,6 @@ func (d *PowerDist) Run(ctx context.Context, cfg config.ExperimentConfig) error 
 				d.config.Dist.Mean,
 				d.config.Dist.MAD,
 				d.config.AlphaParams,
-				d.config.AlphaIgnoreCounts,
 			))
 		}
 	}


### PR DESCRIPTION
This more intuitively groups `IgnoreCounts` together with the other optimization parameters.

Part of #33.