### PR TITLE
Add sample distribution compounding to AnalyticalDistribution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,9 +97,16 @@ type AnalyticalDistribution struct {
 	Alpha    float64 `json:"alpha" default:"3.0"`  // T dist. parameter
 	Compound int     `json:"compound" default:"1"` // sum of N samples
 	// Use Y_i = sum(X_i, ..., X_N+i) for a single stream of X_i.
-	FastCompound bool                         `json:"fast compound"`
-	Normalize    bool                         `json:"normalize"` // divide by Compound
-	DistConfig   stats.RandDistributionConfig `json:"distribution config"`
+	FastCompound bool `json:"fast compound"`
+	// Divide by Compound to preserve mean.
+	Normalize bool `json:"normalize"`
+	// Accumulate DistConfig.Samples to model the compounded distribution, rather
+	// than generating new samples every time.
+	UseSampleDist bool `json:"use sample distribution"`
+	// When > 0, use this to seed the compound distribution populating the final
+	// sample distribution, for use in tests.
+	SampleSeed int                          `json:"sample seed"`
+	DistConfig stats.RandDistributionConfig `json:"distribution config"`
 }
 
 var _ message.Message = &AnalyticalDistribution{}

--- a/config/config.go
+++ b/config/config.go
@@ -100,8 +100,8 @@ type AnalyticalDistribution struct {
 	FastCompound bool `json:"fast compound"`
 	// Divide by Compound to preserve mean.
 	Normalize bool `json:"normalize"`
-	// Accumulate DistConfig.Samples to model the compounded distribution, rather
-	// than generating new samples every time.
+	// Accumulate DistConfig.Samples in SampleDistribution to model the compounded
+	// distribution, rather than generating new samples every time.
 	UseSampleDist bool `json:"use sample distribution"`
 	// When > 0, use this to seed the compound distribution populating the final
 	// sample distribution, for use in tests.

--- a/experiments.go
+++ b/experiments.go
@@ -299,14 +299,14 @@ func AnalyticalDistribution(ctx context.Context, c *config.AnalyticalDistributio
 					sums = sums[1:]
 				}
 				n := c.Compound
-				for len(sums) < n {
+				for len(sums) <= n {
 					var last float64
 					if len(sums) > 0 {
 						last = sums[len(sums)-1]
 					}
 					sums = append(sums, last+d.Rand())
 				}
-				x := sums[n-1] - sums[0]
+				x := sums[n] - sums[0]
 				if c.Normalize {
 					x /= float64(c.Compound)
 				}
@@ -318,6 +318,13 @@ func AnalyticalDistribution(ctx context.Context, c *config.AnalyticalDistributio
 			Fn:        fn,
 		}
 		dist = stats.NewRandDistribution(ctx, dist, xform, &c.DistConfig)
+		if c.UseSampleDist {
+			if c.SampleSeed > 0 {
+				dist.Seed(uint64(c.SampleSeed))
+			}
+			dist = stats.NewSampleDistributionFromRand(
+				dist, c.DistConfig.Samples, &c.DistConfig.Buckets)
+		}
 		distName += fmt.Sprintf(" x %d", c.Compound)
 	}
 	return


### PR DESCRIPTION
As an optimization, add an option to model a compounded distribution by a `SampleDistribution` with a fixed size and populated upfront.

Part of #33.