### PR TITLE
Use SampleDistribution for the source in AnalyticalDistribution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,21 +91,21 @@ func (h *Hold) Name() string { return "hold" }
 
 // AnalyticalDistribution configures the type and parameters of a distibution.
 type AnalyticalDistribution struct {
-	Name     string  `json:"name" required:"true" choices:"t,normal"`
-	Mean     float64 `json:"mean" default:"0.0"`
-	MAD      float64 `json:"MAD" default:"1.0"`
-	Alpha    float64 `json:"alpha" default:"3.0"`  // T dist. parameter
-	Compound int     `json:"compound" default:"1"` // sum of N samples
+	Name  string  `json:"name" required:"true" choices:"t,normal"`
+	Mean  float64 `json:"mean" default:"0.0"`
+	MAD   float64 `json:"MAD" default:"1.0"`
+	Alpha float64 `json:"alpha" default:"3.0"` // T dist. parameter
+	// When > 0, use SampleDistribution with this many samples from the source
+	// distribution, rather than the source distribution directly.
+	SourceSamples int `json:"source samples"`
+	// When > 0, use it to seed the source distribution populating the sample
+	// distribution. For use in tests.
+	Seed     int `json:"seed"`
+	Compound int `json:"compound" default:"1"` // sum of N samples
 	// Use Y_i = sum(X_i, ..., X_N+i) for a single stream of X_i.
 	FastCompound bool `json:"fast compound"`
 	// Divide by Compound to preserve mean.
-	Normalize bool `json:"normalize"`
-	// Accumulate DistConfig.Samples in SampleDistribution to model the compounded
-	// distribution, rather than generating new samples every time.
-	UseSampleDist bool `json:"use sample distribution"`
-	// When > 0, use this to seed the compound distribution populating the final
-	// sample distribution, for use in tests.
-	SampleSeed int                          `json:"sample seed"`
+	Normalize  bool                         `json:"normalize"`
 	DistConfig stats.RandDistributionConfig `json:"distribution config"`
 }
 

--- a/experiments.go
+++ b/experiments.go
@@ -281,6 +281,14 @@ func AnalyticalDistribution(ctx context.Context, c *config.AnalyticalDistributio
 		err = errors.Reason("unsuppoted distribution type: '%s'", c.Name)
 		return
 	}
+	if c.SourceSamples > 0 {
+		if c.Seed > 0 {
+			dist.Seed(uint64(c.Seed))
+		}
+		dist = stats.NewSampleDistributionFromRand(
+			dist, c.SourceSamples, &c.DistConfig.Buckets)
+		distName += fmt.Sprintf("[samples=%d]", c.SourceSamples)
+	}
 	if c.Compound > 1 {
 		fn := func(d stats.Distribution, s interface{}) (float64, interface{}) {
 			acc := 0.0
@@ -318,13 +326,6 @@ func AnalyticalDistribution(ctx context.Context, c *config.AnalyticalDistributio
 			Fn:        fn,
 		}
 		dist = stats.NewRandDistribution(ctx, dist, xform, &c.DistConfig)
-		if c.UseSampleDist {
-			if c.SampleSeed > 0 {
-				dist.Seed(uint64(c.SampleSeed))
-			}
-			dist = stats.NewSampleDistributionFromRand(
-				dist, c.DistConfig.Samples, &c.DistConfig.Buckets)
-		}
 		distName += fmt.Sprintf(" x %d", c.Compound)
 	}
 	return

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -120,8 +120,8 @@ func TestExperiments(t *testing.T) {
   "name": "normal",
   "mean": 1.0,
   "compound": 10,
-  "use sample distribution": true,
-  "sample seed": 42,
+  "source samples": 1000,
+  "seed": 42,
   "normalize": true,
   "distribution config": {
     "samples": 1000,
@@ -131,7 +131,7 @@ func TestExperiments(t *testing.T) {
 				So(cfg.InitMessage(js), ShouldBeNil)
 				d, name, err := AnalyticalDistribution(ctx, &cfg)
 				So(err, ShouldBeNil)
-				So(name, ShouldEqual, "Gauss x 10")
+				So(name, ShouldEqual, "Gauss[samples=1000] x 10")
 				So(testutil.Round(d.Mean(), 2), ShouldEqual, 1.0)
 			})
 		})


### PR DESCRIPTION
It is more interesting to construct a compound distribution out of a sample distribution and compare it to the full compounded source, rather than sampling the compounded source as before.

Part of #33.