### PR TITLE
PowerDist: use SampleDistribution for distribution of statistics

### DIFF
--- a/distribution/distribution.go
+++ b/distribution/distribution.go
@@ -77,13 +77,13 @@ func (d *Distribution) Run(ctx context.Context, cfg config.ExperimentConfig) err
 	if d.histogram.Size() == 0 {
 		return nil
 	}
-	if err := experiments.PlotDistribution(ctx, d.histogram, d.config.LogProfits, d.prefix("log-profit")); err != nil {
+	if err := experiments.PlotDistribution(ctx, stats.NewHistogramDistribution(d.histogram), d.config.LogProfits, d.prefix("log-profit")); err != nil {
 		return errors.Annotate(err, "failed to plot '%s' sample distribution", d.config.ID)
 	}
-	if err := experiments.PlotDistribution(ctx, d.meansHistogram, d.config.Means, d.prefix("means")); err != nil {
+	if err := experiments.PlotDistribution(ctx, stats.NewHistogramDistribution(d.meansHistogram), d.config.Means, d.prefix("means")); err != nil {
 		return errors.Annotate(err, "failed to plot '%s' means distribution", d.config.ID)
 	}
-	if err := experiments.PlotDistribution(ctx, d.madsHistogram, d.config.MADs, d.prefix("MADs")); err != nil {
+	if err := experiments.PlotDistribution(ctx, stats.NewHistogramDistribution(d.madsHistogram), d.config.MADs, d.prefix("MADs")); err != nil {
 		return errors.Annotate(err, "failed to plot '%s' MADs distribution", d.config.ID)
 	}
 	if d.meansHistogram != nil {

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -157,9 +157,9 @@ func TestExperiments(t *testing.T) {
     }
 }`)
 			So(cfg.InitMessage(js), ShouldBeNil)
-			h := stats.NewHistogram(&cfg.Buckets)
-			h.Add(-2.0, -0.5, 0.5, 2.0)
-			So(PlotDistribution(ctx, h, &cfg, "test"), ShouldBeNil)
+			d := stats.NewSampleDistribution(
+				[]float64{-2.0, -0.5, 0.5, 2.0}, &cfg.Buckets)
+			So(PlotDistribution(ctx, d, &cfg, "test"), ShouldBeNil)
 			So(len(g.Plots), ShouldEqual, 4)
 			So(len(cg.Plots), ShouldEqual, 1)
 			So(g.Plots[0].Legend, ShouldEqual, "test p.d.f.")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/stockparfait/errors v0.0.4
 	github.com/stockparfait/logging v0.0.4
 	github.com/stockparfait/parallel v0.0.2
-	github.com/stockparfait/stockparfait v0.1.4
+	github.com/stockparfait/stockparfait v0.1.5
 	github.com/stockparfait/testutil v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/stockparfait/logging v0.0.4 h1:ds+sVkyJP5mE0PjEeHBN9+gMHx67XduL0Xg/yk
 github.com/stockparfait/logging v0.0.4/go.mod h1:wLrsscPazhCAjC/sGmqSA+GghnWUwiSDT/kDwxC0XEI=
 github.com/stockparfait/parallel v0.0.2 h1:EjACOojMU6UZ2yxJNRPhQRFByoFICiobNThKo4CX6l8=
 github.com/stockparfait/parallel v0.0.2/go.mod h1:tbZ3EkWvXo9qbqC2UHr6FynuIaRL9vSBARqFHug7hxA=
-github.com/stockparfait/stockparfait v0.1.4 h1:5O/YP0aryVCJX7r0hFOwi54+tULJzac58T7ypgS3kmw=
-github.com/stockparfait/stockparfait v0.1.4/go.mod h1:doDcKD9L1e+jXM1RNBQcQhHt5QUpqtI+5FOdkx4JE04=
+github.com/stockparfait/stockparfait v0.1.5 h1:4j1/njRevumSZnU0hWK2PCKavxmsCUNQf6QvQTurgUE=
+github.com/stockparfait/stockparfait v0.1.5/go.mod h1:doDcKD9L1e+jXM1RNBQcQhHt5QUpqtI+5FOdkx4JE04=
 github.com/stockparfait/testutil v0.0.1 h1:Qq4RzSl+pA0y+3Jr1fF9CbjTJBwHOWZy8c4RLomHVpc=
 github.com/stockparfait/testutil v0.0.1/go.mod h1:Tr0oAxbuEQ+XjD0BlQLG2wkKDhE2EotCuPAchxH6zew=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This allows for a more accurate computation of mean, MAD, etc. even when the histogram buckets are chosen incorrectly.

Part of #33.