### PR TITLE
Introduce recursive CompoundDistribution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -141,7 +141,7 @@ var _ message.Message = &CompoundDistribution{}
 
 func (d *CompoundDistribution) InitMessage(js interface{}) error {
 	if err := message.Init(d, js); err != nil {
-		return errors.Annotate(err, "failed to init AnalyticalDistribution")
+		return errors.Annotate(err, "failed to init CompoundDistribution")
 	}
 	if (d.AnalyticalSource == nil) == (d.CompoundSource == nil) {
 		return errors.Reason(

--- a/config/config.go
+++ b/config/config.go
@@ -95,21 +95,6 @@ type AnalyticalDistribution struct {
 	Mean  float64 `json:"mean" default:"0.0"`
 	MAD   float64 `json:"MAD" default:"1.0"`
 	Alpha float64 `json:"alpha" default:"3.0"` // T dist. parameter
-	// When > 0, use SampleDistribution with this many samples from the source
-	// distribution, rather than the source distribution directly.
-	SourceSamples int `json:"source samples"`
-	// When > 0, use it to seed the source distribution populating the sample
-	// distribution. For use in tests.
-	Seed     int `json:"seed"`
-	Compound int `json:"compound" default:"1"` // sum of N samples
-	// How to compute the histogram for the compounded distribution:
-	//
-	// - direct: just sample the source N times for each compound sample;
-	// - fast: use Y_i = sum(X_i, ..., X_N+i) for a single stream of X_i;
-	// - biased: use variable substitution and Monte Carlo integration.
-	CompoundType string `json:"compound type" choices:"direct,fast,biased" default:"biased"`
-	// Compound algorithm parameters.
-	DistConfig stats.ParallelSamplingConfig `json:"distribution config"`
 }
 
 var _ message.Message = &AnalyticalDistribution{}
@@ -124,8 +109,46 @@ func (d *AnalyticalDistribution) InitMessage(js interface{}) error {
 	if d.MAD <= 0.0 {
 		return errors.Reason("MAD=%f must be positive", d.MAD)
 	}
-	if d.Compound < 1 {
-		return errors.Reason("Compound=%d must be >= 1", d.Compound)
+	return nil
+}
+
+// CompoundDistribution specifies a compounded source distribution, that is, the
+// distribution of the sum of N samples from the source distribution. The source
+// can in turn be a CompoundDistribution, yielding N1*N2 compounded source, to
+// arbitrary depth.
+type CompoundDistribution struct {
+	// Exactly one of the AnalyticalSource or CompoundSource must be present.
+	AnalyticalSource *AnalyticalDistribution `json:"analytical source"`
+	CompoundSource   *CompoundDistribution   `json:"compound source"`
+	// When > 0, use SampleDistribution with this many samples from the source
+	// distribution, rather than the source distribution directly.
+	SourceSamples int `json:"source samples"`
+	// When > 0, use it to seed the source distribution populating the sample
+	// distribution. For use in tests.
+	SeedSamples int `json:"seed samples"`
+	N           int `json:"n" default:"1"` // sum of n source samples
+	// How to compute the histogram for the compounded distribution:
+	//
+	// - direct: just sample the source N times for each compound sample;
+	// - fast: use Y_i = sum(X_i, ..., X_N+i) for a single stream of X_i;
+	// - biased: use variable substitution and Monte Carlo integration.
+	CompoundType string `json:"compound type" choices:"direct,fast,biased" default:"biased"`
+	// Compound algorithm parameters.
+	Params stats.ParallelSamplingConfig `json:"parameters"`
+}
+
+var _ message.Message = &CompoundDistribution{}
+
+func (d *CompoundDistribution) InitMessage(js interface{}) error {
+	if err := message.Init(d, js); err != nil {
+		return errors.Annotate(err, "failed to init AnalyticalDistribution")
+	}
+	if (d.AnalyticalSource == nil) == (d.CompoundSource == nil) {
+		return errors.Reason(
+			`exactly one of "analytical source" or "compound source" must be specified`)
+	}
+	if d.N < 1 {
+		return errors.Reason("n=%d must be >= 1", d.N)
 	}
 	return nil
 }
@@ -161,26 +184,30 @@ func (f *DeriveAlpha) InitMessage(js interface{}) error {
 	return nil
 }
 
-// DistributionPlot is a config for plotting a given distribution, its
-// statistics, and its approximation by an analytical distribution.
+// DistributionPlot is a config for plotting a given distribution's histogram,
+// its statistics, and its approximation by an analytical distribution.
 type DistributionPlot struct {
-	Graph          string                  `json:"graph" required:"true"`
-	CountsGraph    string                  `json:"counts graph"` // plot buckets' counts
-	ErrorsGraph    string                  `json:"errors graph"` // plot bucket's standard errors
-	Buckets        stats.Buckets           `json:"buckets"`
-	ChartType      string                  `json:"chart type" choices:"line,bars" default:"line"`
-	Normalize      bool                    `json:"normalize"`  // to mean=0, MAD=1
-	UseMeans       bool                    `json:"use means"`  // use bucket means rather than middles
-	KeepZeros      bool                    `json:"keep zeros"` // by default, skip y==0 points
-	LogY           bool                    `json:"log Y"`      // plot log10(y)
-	LeftAxis       bool                    `json:"left axis"`
-	CountsLeftAxis bool                    `json:"counts left axis"`
-	ErrorsLeftAxis bool                    `json:"errors left axis"`
-	RefDist        *AnalyticalDistribution `json:"reference distribution"`
-	AdjustRef      bool                    `json:"adjust reference distribution"`
-	DeriveAlpha    *DeriveAlpha            `json:"derive alpha"` // for ref. dist. from data
-	PlotMean       bool                    `json:"plot mean"`
-	Percentiles    []float64               `json:"percentiles"` // in [0..100]
+	Graph          string                `json:"graph" required:"true"`
+	CountsGraph    string                `json:"counts graph"` // plot buckets' counts
+	ErrorsGraph    string                `json:"errors graph"` // plot bucket's standard errors
+	Buckets        stats.Buckets         `json:"buckets"`
+	ChartType      string                `json:"chart type" choices:"line,bars" default:"line"`
+	Normalize      bool                  `json:"normalize"`  // to mean=0, MAD=1
+	UseMeans       bool                  `json:"use means"`  // use bucket means rather than middles
+	KeepZeros      bool                  `json:"keep zeros"` // by default, skip y==0 points
+	LogY           bool                  `json:"log Y"`      // plot log10(y)
+	LeftAxis       bool                  `json:"left axis"`
+	CountsLeftAxis bool                  `json:"counts left axis"`
+	ErrorsLeftAxis bool                  `json:"errors left axis"`
+	RefDist        *CompoundDistribution `json:"reference distribution"`
+	// When RefDist is an uncompounded (N=1) analytical distribution, its mean and
+	// MAD will be automatically adjusted when AdjustRef is true.
+	AdjustRef bool `json:"adjust reference distribution"`
+	// Similarly, for uncompound t-distribution RefDist, alpha is derived from the
+	// data.
+	DeriveAlpha *DeriveAlpha `json:"derive alpha"`
+	PlotMean    bool         `json:"plot mean"`
+	Percentiles []float64    `json:"percentiles"` // in [0..100]
 }
 
 var _ message.Message = &DistributionPlot{}
@@ -272,9 +299,9 @@ func (c *CumulativeStatistic) InitMessage(js interface{}) error {
 }
 
 type PowerDist struct {
-	ID         string                 `json:"id"` // experiment ID, for multiple instances
-	Dist       AnalyticalDistribution `json:"distribution"`
-	SamplePlot *DistributionPlot      `json:"sample plot"` // sampled Dist
+	ID         string               `json:"id"` // experiment ID, for multiple instances
+	Dist       CompoundDistribution `json:"distribution"`
+	SamplePlot *DistributionPlot    `json:"sample plot"` // sampled Dist
 
 	// Graphs of cumulative statistics, up to Samples, all generated from the same
 	// sequence of values.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,7 +69,7 @@ func TestConfig(t *testing.T) {
       "log-profits": {
         "graph": "dist",
         "normalize": true,
-        "reference distribution": {"name": "t"},
+        "reference distribution": {"analytical source": {"name": "t"}},
         "derive alpha": {
           "min x": 2,
           "max x": 4
@@ -78,7 +78,7 @@ func TestConfig(t *testing.T) {
       "parallel workers": 1
     }},
     {"power distribution": {
-      "distribution": {"name": "normal"},
+      "distribution": {"analytical source": {"name": "normal"}},
       "cumulative mean": {"graph": "cumul mean"}
     }}
   ]
@@ -167,14 +167,16 @@ func TestConfig(t *testing.T) {
 							Buckets:   defaultBuckets,
 							ChartType: "line",
 							Normalize: true,
-							RefDist: &AnalyticalDistribution{
-								Name:         "t",
-								Mean:         0.0,
-								MAD:          1.0,
-								Alpha:        3.0,
-								Compound:     1,
+							RefDist: &CompoundDistribution{
+								AnalyticalSource: &AnalyticalDistribution{
+									Name:  "t",
+									Mean:  0.0,
+									MAD:   1.0,
+									Alpha: 3.0,
+								},
+								N:            1,
 								CompoundType: "biased",
-								DistConfig:   defaultParallelSampling,
+								Params:       defaultParallelSampling,
 							},
 							DeriveAlpha: &DeriveAlpha{
 								MinX:          2.0,
@@ -189,13 +191,15 @@ func TestConfig(t *testing.T) {
 						Workers:   1,
 					}},
 					{Config: &PowerDist{
-						Dist: AnalyticalDistribution{
-							Name:         "normal",
-							MAD:          1.0,
-							Alpha:        3.0,
-							Compound:     1,
+						Dist: CompoundDistribution{
+							AnalyticalSource: &AnalyticalDistribution{
+								Name:  "normal",
+								MAD:   1.0,
+								Alpha: 3.0,
+							},
+							N:            1,
 							CompoundType: "biased",
-							DistConfig:   defaultParallelSampling,
+							Params:       defaultParallelSampling,
 						},
 						CumulMean: &CumulativeStatistic{
 							Graph:   "cumul mean",

--- a/distribution/assets/Distribution-all-stocks-with-samples.json
+++ b/distribution/assets/Distribution-all-stocks-with-samples.json
@@ -4,11 +4,13 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "end": "2022-07-31",
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -25,8 +27,10 @@
           "log Y": true,
           "normalize": true,
           "reference distribution": {
-            "alpha": 3.0,
-            "name": "t"
+            "analytical source": {
+              "alpha": 3.0,
+              "name": "t"
+            }
           },
           "use means": true
         }
@@ -42,8 +46,8 @@
         },
         {
           "id": "counts",
-          "title": "Number of Samples",
-          "log scale Y": true
+          "log scale Y": true,
+          "title": "Number of Samples"
         }
       ],
       "id": "dist group",

--- a/distribution/assets/Vol-1M-stocks.json
+++ b/distribution/assets/Vol-1M-stocks.json
@@ -4,7 +4,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -12,6 +11,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -28,8 +30,10 @@
           "log Y": true,
           "normalize": true,
           "reference distribution": {
-            "alpha": 3.0,
-            "name": "t"
+            "analytical source": {
+              "alpha": 3.0,
+              "name": "t"
+            }
           },
           "use means": true
         }
@@ -45,8 +49,8 @@
         },
         {
           "id": "counts",
-          "title": "Number of Samples",
-          "log scale Y": true
+          "log scale Y": true,
+          "title": "Number of Samples"
         }
       ],
       "id": "dist group",

--- a/distribution/assets/all-stocks-normal.json
+++ b/distribution/assets/all-stocks-normal.json
@@ -4,7 +4,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -12,6 +11,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -27,7 +29,9 @@
           "log Y": true,
           "normalize": true,
           "reference distribution": {
-            "name": "normal"
+            "analytical source": {
+              "name": "normal"
+            }
           },
           "use means": true
         }

--- a/distribution/assets/by-sectors.json
+++ b/distribution/assets/by-sectors.json
@@ -4,7 +4,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -15,6 +14,9 @@
           ],
           "sectors": [
             "Basic Materials"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -37,7 +39,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -48,6 +49,9 @@
           ],
           "sectors": [
             "Communication Services"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -70,7 +74,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -81,6 +84,9 @@
           ],
           "sectors": [
             "Consumer Cyclical"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -103,7 +109,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -114,6 +119,9 @@
           ],
           "sectors": [
             "Consumer Defensive"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -136,7 +144,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -147,6 +154,9 @@
           ],
           "sectors": [
             "Energy"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -162,8 +172,10 @@
           "log Y": true,
           "normalize": true,
           "reference distribution": {
-            "alpha": 3.0,
-            "name": "t"
+            "analytical source": {
+              "alpha": 3.0,
+              "name": "t"
+            }
           },
           "use means": true
         }
@@ -173,7 +185,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -184,6 +195,9 @@
           ],
           "sectors": [
             "Financial Services"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -206,7 +220,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -217,6 +230,9 @@
           ],
           "sectors": [
             "Healthcare"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -239,7 +255,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -250,6 +265,9 @@
           ],
           "sectors": [
             "Industrials"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -272,7 +290,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -283,6 +300,9 @@
           ],
           "sectors": [
             "Real Estate"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -305,7 +325,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -316,6 +335,9 @@
           ],
           "sectors": [
             "Technology"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -338,7 +360,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -349,6 +370,9 @@
           ],
           "sectors": [
             "Utilities"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },

--- a/distribution/assets/by-volume.json
+++ b/distribution/assets/by-volume.json
@@ -4,7 +4,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "max": 10000000,
             "min": 1000000
@@ -13,6 +12,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -28,8 +30,10 @@
           "log Y": true,
           "normalize": true,
           "reference distribution": {
-            "alpha": 3.0,
-            "name": "t"
+            "analytical source": {
+              "alpha": 3.0,
+              "name": "t"
+            }
           },
           "use means": true
         }
@@ -39,7 +43,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "max": 100000000,
             "min": 10000000
@@ -48,6 +51,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -70,7 +76,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "max": 1000000000,
             "min": 100000000
@@ -79,6 +84,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },

--- a/distribution/assets/by-years.json
+++ b/distribution/assets/by-years.json
@@ -4,7 +4,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -12,6 +11,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "1998-01-01"
         },
@@ -34,7 +36,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -42,6 +43,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "2004-01-01"
         },
@@ -64,7 +68,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -72,6 +75,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "2010-01-01"
         },
@@ -94,7 +100,6 @@
       "distribution": {
         "data": {
           "DB": "sharadar",
-          "sources": ["SEP"],
           "cash volume": {
             "min": 1000000
           },
@@ -102,6 +107,9 @@
           "exclude tickers": [
             "JWACU",
             "BOALY"
+          ],
+          "sources": [
+            "SEP"
           ],
           "start": "2016-01-01"
         },
@@ -117,8 +125,10 @@
           "log Y": true,
           "normalize": true,
           "reference distribution": {
-            "alpha": 3.0,
-            "name": "t"
+            "analytical source": {
+              "alpha": 3.0,
+              "name": "t"
+            }
           },
           "use means": true
         }

--- a/distribution/distribution_test.go
+++ b/distribution/distribution_test.go
@@ -118,8 +118,8 @@ func TestDistribution(t *testing.T) {
 				"test tickers":          "2",
 				"test average MAD":      "0.1347",
 				"test average mean":     "0.04766",
-				"test log-profit mean":  "0.04766", // actual: 0
-				"test log-profit MAD":   "0.1347",  // actual: 1
+				"test log-profit mean":  "0.04766",
+				"test log-profit MAD":   "0.1347",
 				"test log-profit alpha": "3",
 			})
 			So(len(g.Plots), ShouldEqual, 8)

--- a/distribution/distribution_test.go
+++ b/distribution/distribution_test.go
@@ -106,7 +106,7 @@ func TestDistribution(t *testing.T) {
     "chart type": "bars",
     "plot mean": true,
     "percentiles": [5, 95],
-    "reference distribution": {"name": "t"}
+    "reference distribution": {"analytical source": {"name": "t"}}
   },
   "means": {"graph": "g"},
   "MADs": {"graph": "g"}
@@ -118,8 +118,8 @@ func TestDistribution(t *testing.T) {
 				"test tickers":          "2",
 				"test average MAD":      "0.1347",
 				"test average mean":     "0.04766",
-				"test log-profit mean":  "0",
-				"test log-profit MAD":   "1",
+				"test log-profit mean":  "0.04766", // actual: 0
+				"test log-profit MAD":   "0.1347",  // actual: 1
 				"test log-profit alpha": "3",
 			})
 			So(len(g.Plots), ShouldEqual, 8)

--- a/experiments.go
+++ b/experiments.go
@@ -433,7 +433,7 @@ func plotAnalytical(ctx context.Context, dh stats.DistributionWithHistogram, c *
 	if c.RefDist == nil {
 		return nil
 	}
-	dc := *c.RefDist // shallow copy, to modify locally
+	dc := *c.RefDist // semi-deep copy, to modify locally
 	var ac config.AnalyticalDistribution
 	if dc.AnalyticalSource != nil {
 		ac = *dc.AnalyticalSource

--- a/experiments.go
+++ b/experiments.go
@@ -362,8 +362,7 @@ func Compound(ctx context.Context, d stats.Distribution, n int, compType string,
 	return
 }
 
-// AnalyticalDistribution instantiates a distribution from the corresponding
-// config.
+// AnalyticalDistribution instantiates a distribution from config.
 func AnalyticalDistribution(ctx context.Context, c *config.AnalyticalDistribution) (dist stats.Distribution, distName string, err error) {
 	switch c.Name {
 	case "t":
@@ -376,23 +375,46 @@ func AnalyticalDistribution(ctx context.Context, c *config.AnalyticalDistributio
 		err = errors.Reason("unsuppoted distribution type: '%s'", c.Name)
 		return
 	}
-	if c.SourceSamples > 0 {
-		if c.Seed > 0 {
-			dist.Seed(uint64(c.Seed))
+	return
+}
+
+// CompoundDistribution instantiates a compounded distribution from config.
+// When c.N=1, the source distribution is passed through as is.
+func CompoundDistribution(ctx context.Context, c *config.CompoundDistribution) (dist stats.Distribution, distName string, err error) {
+	switch {
+	case c.AnalyticalSource != nil:
+		dist, distName, err = AnalyticalDistribution(ctx, c.AnalyticalSource)
+		if err != nil {
+			err = errors.Annotate(err, "failed to create analytical distribution")
+			return
 		}
-		dist = stats.NewSampleDistributionFromRand(
-			dist, c.SourceSamples, &c.DistConfig.Buckets)
-		distName += fmt.Sprintf("[samples=%d]", c.SourceSamples)
-	}
-	if c.Compound == 1 {
+	case c.CompoundSource != nil:
+		dist, distName, err = CompoundDistribution(ctx, c.CompoundSource)
+		if err != nil {
+			err = errors.Annotate(err, "failed to create inner compound distribution")
+			return
+		}
+	default:
+		err = errors.Reason("both analytical and compound sources are nil")
 		return
 	}
-	dist, err = Compound(ctx, dist, c.Compound, c.CompoundType, &c.DistConfig)
+	if c.SourceSamples > 0 {
+		if c.SeedSamples > 0 {
+			dist.Seed(uint64(c.SeedSamples))
+		}
+		dist = stats.NewSampleDistributionFromRand(
+			dist, c.SourceSamples, &c.Params.Buckets)
+		distName += fmt.Sprintf("[samples=%d]", c.SourceSamples)
+	}
+	if c.N == 1 {
+		return
+	}
+	dist, err = Compound(ctx, dist, c.N, c.CompoundType, &c.Params)
 	if err != nil {
 		err = errors.Annotate(err, "failed to compound the distribution")
 		return
 	}
-	distName += fmt.Sprintf(" x %d", c.Compound)
+	distName += fmt.Sprintf(" x %d", c.N)
 	return
 }
 
@@ -412,9 +434,14 @@ func plotAnalytical(ctx context.Context, dh stats.DistributionWithHistogram, c *
 		return nil
 	}
 	dc := *c.RefDist // shallow copy, to modify locally
-	if c.AdjustRef {
-		dc.Mean = dh.Mean()
-		dc.MAD = dh.MAD()
+	var ac config.AnalyticalDistribution
+	if dc.AnalyticalSource != nil {
+		ac = *dc.AnalyticalSource
+		dc.AnalyticalSource = &ac
+	}
+	if c.AdjustRef && dc.N == 1 && dc.AnalyticalSource != nil {
+		ac.Mean = dh.Mean()
+		ac.MAD = dh.MAD()
 	}
 
 	h := dh.Histogram()
@@ -424,22 +451,23 @@ func plotAnalytical(ctx context.Context, dh stats.DistributionWithHistogram, c *
 	} else {
 		xs = h.Buckets().Xs(0.5)
 	}
-	if c.DeriveAlpha != nil {
-		dc.Alpha = DeriveAlpha(h, dc.Mean, dc.MAD, c.DeriveAlpha)
+	if c.DeriveAlpha != nil && dc.N == 1 && dc.AnalyticalSource != nil && ac.Name == "t" {
+		ac.Alpha = DeriveAlpha(h, ac.Mean, ac.MAD, c.DeriveAlpha)
 	}
 
-	if err := AddValue(ctx, legend+" mean", fmt.Sprintf("%.4g", dc.Mean)); err != nil {
+	if err := AddValue(ctx, legend+" mean", fmt.Sprintf("%.4g", dh.Mean())); err != nil {
 		return errors.Annotate(err, "failed to add value for '%s mean'", legend)
 	}
-	if err := AddValue(ctx, legend+" MAD", fmt.Sprintf("%.4g", dc.MAD)); err != nil {
+	if err := AddValue(ctx, legend+" MAD", fmt.Sprintf("%.4g", dh.MAD())); err != nil {
 		return errors.Annotate(err, "failed to add value for '%s MAD'", legend)
 	}
-	if dc.Name == "t" {
-		if err := AddValue(ctx, legend+" alpha", fmt.Sprintf("%.4g", dc.Alpha)); err != nil {
+	if dc.AnalyticalSource != nil && dc.AnalyticalSource.Name == "t" {
+		alpha := fmt.Sprintf("%.4g", dc.AnalyticalSource.Alpha)
+		if err := AddValue(ctx, legend+" alpha", alpha); err != nil {
 			return errors.Annotate(err, "failed to add value for '%s alpha'", legend)
 		}
 	}
-	dist, distName, err := AnalyticalDistribution(ctx, &dc)
+	dist, distName, err := CompoundDistribution(ctx, &dc)
 	if err != nil {
 		return errors.Annotate(err, "failed to instantiate reference distribution")
 	}

--- a/powerdist/assets/normal-N-20M-mean-mad-sigma.json
+++ b/powerdist/assets/normal-N-20M-mean-mad-sigma.json
@@ -14,20 +14,21 @@
           "plot mean": true
         },
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "normal",
-          "distribution config": {
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3,
+            "mean": 0.0,
+            "name": "normal"
+          },
+          "parameters": {
             "buckets": {
               "max": 7,
               "min": 0.1,
               "n": 101,
               "spacing": "symmetric exponential"
-	    },
+            },
             "samples": 20000000
-	  }
+          }
         },
         "id": "N=20000000 @ 1",
         "mean distribution": {
@@ -56,9 +57,11 @@
             99.5
           ],
           "reference distribution": {
-            "MAD": 1.0,
-            "mean": 0.0,
-            "name": "normal"
+            "analytical source": {
+              "MAD": 1.0,
+              "mean": 0.0,
+              "name": "normal"
+            }
           }
         },
         "sigma distribution": {

--- a/powerdist/assets/normal-N-250-mean-mad-sigma.json
+++ b/powerdist/assets/normal-N-250-mean-mad-sigma.json
@@ -15,20 +15,21 @@
           "plot mean": true
         },
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "normal",
-          "distribution config": {
-	    "buckets": {
-	      "max": 5,
-	      "min": 0.1,
-	      "n": 101,
-	      "spacing": "symmetric exponential"
-	    },
-	    "samples": 250
-	  }
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3,
+            "mean": 0.0,
+            "name": "normal"
+          },
+          "parameters": {
+            "buckets": {
+              "max": 5,
+              "min": 0.1,
+              "n": 101,
+              "spacing": "symmetric exponential"
+            },
+            "samples": 250
+          }
         },
         "id": "N=250 @ 1",
         "mean distribution": {
@@ -59,9 +60,11 @@
             99.5
           ],
           "reference distribution": {
-            "MAD": 1.0,
-            "mean": 0.0,
-            "name": "normal"
+            "analytical source": {
+              "MAD": 1.0,
+              "mean": 0.0,
+              "name": "normal"
+            }
           }
         },
         "sigma distribution": {

--- a/powerdist/assets/normal-N-5K-mean-mad-sigma.json
+++ b/powerdist/assets/normal-N-5K-mean-mad-sigma.json
@@ -14,20 +14,21 @@
           "plot mean": true
         },
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "normal",
-          "distribution config": {
-	    "buckets": {
-	      "max": 7,
-	      "min": 0.1,
-	      "n": 101,
-	      "spacing": "symmetric exponential"
-	    },
-	    "samples": 5000
-	  }
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3,
+            "mean": 0.0,
+            "name": "normal"
+          },
+          "parameters": {
+            "buckets": {
+              "max": 7,
+              "min": 0.1,
+              "n": 101,
+              "spacing": "symmetric exponential"
+            },
+            "samples": 5000
+          }
         },
         "id": "N=5000 @ 1",
         "mean distribution": {
@@ -56,9 +57,11 @@
             99.5
           ],
           "reference distribution": {
-            "MAD": 1.0,
-            "mean": 0.0,
-            "name": "normal"
+            "analytical source": {
+              "MAD": 1.0,
+              "mean": 0.0,
+              "name": "normal"
+            }
           }
         },
         "sigma distribution": {

--- a/powerdist/assets/t-N-20M-all-dist.json
+++ b/powerdist/assets/t-N-20M-all-dist.json
@@ -35,12 +35,13 @@
           "min x": 1.1
         },
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "t",
-          "distribution config": {
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3,
+            "mean": 0.0,
+            "name": "t"
+          },
+          "parameters": {
             "buckets": {
               "max": 300,
               "min": 0.1,
@@ -81,9 +82,11 @@
             99.5
           ],
           "reference distribution": {
-            "MAD": 1.0,
-            "mean": 0.0,
-            "name": "t"
+            "analytical source": {
+              "MAD": 1.0,
+              "mean": 0.0,
+              "name": "t"
+            }
           }
         },
         "sigma distribution": {

--- a/powerdist/assets/t-N-250-mean-mad-sigma.json
+++ b/powerdist/assets/t-N-250-mean-mad-sigma.json
@@ -14,20 +14,21 @@
           "plot mean": true
         },
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "t",
-          "distribution config": {
-	    "buckets": {
-	      "max": 8,
-	      "min": 0.1,
-	      "n": 101,
-	      "spacing": "symmetric exponential"
-	    },
-	    "samples": 250
-	  }
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3,
+            "mean": 0.0,
+            "name": "t"
+          },
+          "parameters": {
+            "buckets": {
+              "max": 8,
+              "min": 0.1,
+              "n": 101,
+              "spacing": "symmetric exponential"
+            },
+            "samples": 250
+          }
         },
         "id": "N=250 @ 1",
         "mean distribution": {
@@ -56,9 +57,11 @@
             99.5
           ],
           "reference distribution": {
-            "MAD": 1.0,
-            "mean": 0.0,
-            "name": "t"
+            "analytical source": {
+              "MAD": 1.0,
+              "mean": 0.0,
+              "name": "t"
+            }
           }
         },
         "sigma distribution": {

--- a/powerdist/assets/t-N-5K-all-dist.json
+++ b/powerdist/assets/t-N-5K-all-dist.json
@@ -35,12 +35,13 @@
           "min x": 1.1
         },
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "t",
-          "distribution config": {
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3,
+            "mean": 0,
+            "name": "t"
+          },
+          "parameters": {
             "buckets": {
               "max": 20,
               "min": 0.1,
@@ -81,9 +82,11 @@
             99.5
           ],
           "reference distribution": {
-            "MAD": 1.0,
-            "mean": 0.0,
-            "name": "t"
+            "analytical source": {
+              "MAD": 1.0,
+              "mean": 0.0,
+              "name": "t"
+            }
           }
         },
         "sigma distribution": {

--- a/powerdist/assets/t-a28-vs-a32-linear.json
+++ b/powerdist/assets/t-a28-vs-a32-linear.json
@@ -3,12 +3,13 @@
     {
       "power distribution": {
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 2.8,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "t",
-          "distribution config": {
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 2.8,
+            "mean": 0.0,
+            "name": "t"
+          },
+          "parameters": {
             "buckets": {
               "max": 30,
               "min": 0.1,
@@ -30,10 +31,12 @@
           "log Y": false,
           "percentiles": [],
           "reference distribution": {
-            "MAD": 1.0,
-            "alpha": 2.8,
-            "mean": 0.0,
-            "name": "t"
+            "analytical source": {
+              "MAD": 1.0,
+              "alpha": 2.8,
+              "mean": 0.0,
+              "name": "t"
+            }
           }
         },
         "statistic samples": 100
@@ -42,12 +45,13 @@
     {
       "power distribution": {
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3.2,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "t",
-          "distribution config": {
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3.2,
+            "mean": 0.0,
+            "name": "t"
+          },
+          "parameters": {
             "buckets": {
               "max": 30,
               "min": 0.1,
@@ -69,10 +73,12 @@
           "log Y": false,
           "percentiles": [],
           "reference distribution": {
-            "MAD": 1.0,
-            "alpha": 3.2,
-            "mean": 0.0,
-            "name": "t"
+            "analytical source": {
+              "MAD": 1.0,
+              "alpha": 3.2,
+              "mean": 0.0,
+              "name": "t"
+            }
           }
         },
         "statistic samples": 10000

--- a/powerdist/assets/t-a28-vs-a32-log.json
+++ b/powerdist/assets/t-a28-vs-a32-log.json
@@ -3,12 +3,13 @@
     {
       "power distribution": {
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 2.8,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "t",
-          "distribution config": {
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 2.8,
+            "mean": 0.0,
+            "name": "t"
+          },
+          "parameters": {
             "buckets": {
               "max": 300,
               "min": 0.1,
@@ -30,10 +31,12 @@
           "log Y": true,
           "percentiles": [],
           "reference distribution": {
-            "MAD": 1.0,
-            "alpha": 2.8,
-            "mean": 0.0,
-            "name": "t"
+            "analytical source": {
+              "MAD": 1.0,
+              "alpha": 2.8,
+              "mean": 0.0,
+              "name": "t"
+            }
           }
         },
         "statistic samples": 100
@@ -42,12 +45,13 @@
     {
       "power distribution": {
         "distribution": {
-          "MAD": 1.0,
-          "alpha": 3.2,
-          "compound": 1,
-          "mean": 0.0,
-          "name": "t",
-          "distribution config": {
+          "analytical source": {
+            "MAD": 1.0,
+            "alpha": 3.2,
+            "mean": 0.0,
+            "name": "t"
+          },
+          "parameters": {
             "buckets": {
               "max": 300,
               "min": 0.1,
@@ -69,10 +73,12 @@
           "log Y": true,
           "percentiles": [],
           "reference distribution": {
-            "MAD": 1.0,
-            "alpha": 3.2,
-            "mean": 0.0,
-            "name": "t"
+            "analytical source": {
+              "MAD": 1.0,
+              "alpha": 3.2,
+              "mean": 0.0,
+              "name": "t"
+            }
           }
         },
         "statistic samples": 10000

--- a/powerdist/powerdist_test.go
+++ b/powerdist/powerdist_test.go
@@ -51,7 +51,7 @@ func TestDistribution(t *testing.T) {
 			var cfg config.PowerDist
 			JSConfig := `
 {
-  "distribution": {"name": "t"}
+  "distribution": {"analytical source": {"name": "t"}}
 }
 `
 			So(cfg.InitMessage(testutil.JSON(JSConfig)), ShouldBeNil)
@@ -64,8 +64,8 @@ func TestDistribution(t *testing.T) {
 			JSConfig := `
 {
   "distribution": {
-    "name": "t",
-    "distribution config": {
+    "analytical source": {"name": "t"},
+    "parameters": {
       "buckets": {"n": 5},
       "samples": 10
     }


### PR DESCRIPTION
It makes `AnalyticalDistribution` just a plain normal or t-distribution, as it should be, and allows `CompoundDistribution` to take either `AnalyticalDistribution` or another recursive `CompoundDistribution` as the source for compounding.

Part of #33.