### PR TITLE
Add P(X < mean-10*sigma) and P(X > mean+10*sigma) estimates

### DIFF
--- a/distribution/distribution_test.go
+++ b/distribution/distribution_test.go
@@ -85,8 +85,10 @@ func TestDistribution(t *testing.T) {
 			var dist Distribution
 			So(dist.Run(ctx, &cfg), ShouldBeNil)
 			So(values, ShouldResemble, experiments.Values{
-				"samples": "4",
-				"tickers": "2",
+				"log-profit P(X < mean-10*sigma)": "0.5481",
+				"log-profit P(X > mean+10*sigma)": "0.4519",
+				"samples":                         "4",
+				"tickers":                         "2",
 			})
 			So(len(g.Plots), ShouldEqual, 1)
 		})
@@ -114,14 +116,19 @@ func TestDistribution(t *testing.T) {
 			var dist Distribution
 			So(dist.Run(ctx, &cfg), ShouldBeNil)
 			So(values, ShouldResemble, experiments.Values{
-				"test samples":          "4",
-				"test tickers":          "2",
-				"test average MAD":      "0.1347",
-				"test average mean":     "0.04766",
-				"test log-profit mean":  "0.04766",
-				"test log-profit MAD":   "0.1347",
-				"test log-profit alpha": "3",
-			})
+				"test samples":                         "4",
+				"test tickers":                         "2",
+				"test average MAD":                     "0.1347",
+				"test MADs P(X < mean-10*sigma)":       "0.636",
+				"test MADs P(X > mean+10*sigma)":       "0.364",
+				"test average mean":                    "0.04766",
+				"test means P(X < mean-10*sigma)":      "0.5481",
+				"test means P(X > mean+10*sigma)":      "0.4519",
+				"test log-profit mean":                 "0.04766",
+				"test log-profit MAD":                  "0.1347",
+				"test log-profit alpha":                "3",
+				"test log-profit P(X < mean-10*sigma)": "0",
+				"test log-profit P(X > mean+10*sigma)": "0"})
 			So(len(g.Plots), ShouldEqual, 8)
 			So(g.Plots[1].Legend, ShouldEqual, "test log-profit counts")
 			// The first value is skipped due to 0 count.

--- a/experiments.go
+++ b/experiments.go
@@ -174,6 +174,12 @@ func PlotDistribution(ctx context.Context, dh stats.DistributionWithHistogram, c
 	if err := plotAnalytical(ctx, dh, c, legend); err != nil {
 		return errors.Annotate(err, "failed to plot '%s ref dist'", legend)
 	}
+	if err := AddValue(ctx, legend+" P(X < mean-10*sigma)", fmt.Sprintf("%.4g", dh.CDF(dh.Mean()-10*math.Sqrt(dh.Variance())))); err != nil {
+		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
+	}
+	if err := AddValue(ctx, legend+" P(X > mean+10*sigma)", fmt.Sprintf("%.4g", 1.0-dh.CDF(dh.Mean()+10*math.Sqrt(dh.Variance())))); err != nil {
+		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
+	}
 	return nil
 }
 

--- a/experiments.go
+++ b/experiments.go
@@ -178,7 +178,7 @@ func PlotDistribution(ctx context.Context, dh stats.DistributionWithHistogram, c
 		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
 	}
 	if err := AddValue(ctx, legend+" P(X > mean+10*sigma)", fmt.Sprintf("%.4g", 1.0-dh.CDF(dh.Mean()+10*math.Sqrt(dh.Variance())))); err != nil {
-		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
+		return errors.Annotate(err, "failed to add value for '%s P(X > mean+10*sigma)'", legend)
 	}
 	return nil
 }


### PR DESCRIPTION
Print probabilities for `10*sigma` events for every plotted distribution. This is mostly useful as a point of reference in the docs, to illustrate the idea of "black swans".

Part of #24.