### PR TITLE
Standardize the experiment ID

### DIFF
--- a/autocorr/autocorr.go
+++ b/autocorr/autocorr.go
@@ -36,11 +36,12 @@ type AutoCorrelation struct {
 
 var _ experiments.Experiment = &AutoCorrelation{}
 
-func (e *AutoCorrelation) prefix(s string) string {
-	if e.config.ID == "" {
-		return s
-	}
-	return e.config.ID + " " + s
+func (e *AutoCorrelation) Prefix(s string) string {
+	return experiments.Prefix(e.config.ID, s)
+}
+
+func (e *AutoCorrelation) AddValue(ctx context.Context, k, v string) error {
+	return experiments.AddValue(ctx, e.config.ID, k, v)
 }
 
 func (e *AutoCorrelation) Run(ctx context.Context, cfg config.ExperimentConfig) error {
@@ -118,7 +119,7 @@ func (e *AutoCorrelation) addPlot(total jobResult) error {
 	if err != nil {
 		return errors.Annotate(err, "failed to create auto-correlation plot")
 	}
-	legend := e.prefix("Auto-correlation")
+	legend := e.Prefix("Auto-correlation")
 	plt.SetLegend(legend).SetYLabel("correlation")
 	if err := plot.Add(e.context, plt, e.config.Graph); err != nil {
 		return errors.Annotate(err, "failed to add '%s' plot", legend)
@@ -153,7 +154,7 @@ func (e *AutoCorrelation) processAnalytical() error {
 		}
 		total.Merge(r)
 	}
-	err = experiments.AddValue(e.context, e.prefix("samples"), fmt.Sprintf("%d", total.ns[0]))
+	err = e.AddValue(e.context, "samples", fmt.Sprintf("%d", total.ns[0]))
 	if err != nil {
 		return errors.Annotate(err, "failed to add value for number of samples")
 	}
@@ -239,11 +240,11 @@ func (e *AutoCorrelation) processTickers(tickers []string) error {
 		numTickers++
 		total.Merge(r)
 	}
-	err := experiments.AddValue(e.context, e.prefix("tickers"), fmt.Sprintf("%d", numTickers))
+	err := e.AddValue(e.context, "tickers", fmt.Sprintf("%d", numTickers))
 	if err != nil {
 		return errors.Annotate(err, "failed to add value for number of tickers")
 	}
-	err = experiments.AddValue(e.context, e.prefix("samples"), fmt.Sprintf("%d", total.ns[0]))
+	err = e.AddValue(e.context, "samples", fmt.Sprintf("%d", total.ns[0]))
 	if err != nil {
 		return errors.Annotate(err, "failed to add value for number of samples")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type ExperimentConfig interface {
 
 // TestExperimentConfig is only used in tests.
 type TestExperimentConfig struct {
+	ID     string  `json:"id"`
 	Grade  float64 `json:"grade" default:"2.0"`
 	Passed bool    `json:"passed"`
 	Graph  string  `json:"graph" required:"true"`
@@ -69,8 +70,9 @@ func (p *HoldPosition) InitMessage(js any) error {
 	return nil
 }
 
-// Hold "experiment" configuration.
+// Hold experiment configuration.
 type Hold struct {
+	ID             string         `json:"id"`
 	Reader         *db.Reader     `json:"data" required:"true"`
 	Positions      []HoldPosition `json:"positions"`
 	PositionsGraph string         `json:"positions graph"` // plots per position

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -247,7 +247,7 @@ func TestExperiments(t *testing.T) {
 			So(cfg.InitMessage(js), ShouldBeNil)
 			d := stats.NewSampleDistribution(
 				[]float64{-2.0, -0.5, 0.5, 2.0}, &cfg.Buckets)
-			So(PlotDistribution(ctx, d, &cfg, "test"), ShouldBeNil)
+			So(PlotDistribution(ctx, d, &cfg, "", "test"), ShouldBeNil)
 
 			So(len(g.Plots), ShouldEqual, 4)
 			So(g.Plots[0].Legend, ShouldEqual, "test p.d.f.")

--- a/hold/hold.go
+++ b/hold/hold.go
@@ -41,6 +41,14 @@ type Hold struct {
 
 var _ experiments.Experiment = &Hold{}
 
+func (h *Hold) Prefix(s string) string {
+	return experiments.Prefix(h.config.ID, s)
+}
+
+func (h *Hold) AddValue(ctx context.Context, k, v string) error {
+	return experiments.AddValue(ctx, h.config.ID, k, v)
+}
+
 // Run implements experiments.Experiment.
 func (h *Hold) Run(ctx context.Context, cfg config.ExperimentConfig) error {
 	var ok bool

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -36,6 +36,14 @@ type Portfolio struct {
 
 var _ experiments.Experiment = &Portfolio{}
 
+func (p *Portfolio) Prefix(s string) string {
+	return experiments.Prefix(p.config.ID, s)
+}
+
+func (p *Portfolio) AddValue(ctx context.Context, k, v string) error {
+	return experiments.AddValue(ctx, p.config.ID, k, v)
+}
+
 // Row of the output table as the list of strings compatible with encoding/csv.
 type Row []string
 


### PR DESCRIPTION
All the experiments now require to implement `Prefix()` and `AddValue()`, effectively reminding to add a configured ID to each experiment.

Resolves #14.