### PR TITLE
Beta: save and reuse lengths of log-profit sequences

### DIFF
--- a/beta/beta_test.go
+++ b/beta/beta_test.go
@@ -122,6 +122,7 @@ func TestBeta(t *testing.T) {
 			Convey("all graphs", func() {
 				var cfg config.Beta
 				csvFile := filepath.Join(tmpdir, "betas.csv")
+				lengthsFile := filepath.Join(tmpdir, "lengths.json")
 				confJSON := fmt.Sprintf(`
 {
   "id": "testID",
@@ -136,18 +137,20 @@ func TestBeta(t *testing.T) {
     "tickers": ["A", "B"]
   },
   "file": "%s",
+  "lengths file": "%s",
   "beta plot": {"graph": "beta"},
   "R plot": {"graph": "R"},
   "R means": {"graph": "means"},
   "R MADs": {"graph": "mads"},
   "R Sigmas": {"graph": "sigmas"},
   "lengths plot": {"graph": "lengths"}
-}`, tmpdir, dbName, tmpdir, dbName, csvFile)
+}`, tmpdir, dbName, tmpdir, dbName, csvFile, lengthsFile)
 				So(cfg.InitMessage(testutil.JSON(confJSON)), ShouldBeNil)
 				var betaExp Beta
 				So(betaExp.Run(ctx, &cfg), ShouldBeNil)
 
 				So(testutil.FileExists(csvFile), ShouldBeTrue)
+				So(testutil.FileExists(lengthsFile), ShouldBeTrue)
 				So(len(betaGraph.Plots), ShouldEqual, 1)
 				So(len(RGraph.Plots), ShouldEqual, 1)
 				So(len(MeansGraph.Plots), ShouldEqual, 1)
@@ -194,6 +197,11 @@ func TestBeta(t *testing.T) {
 
 func TestIterators(t *testing.T) {
 	t.Parallel()
+
+	Convey("repeatIter works", t, func() {
+		So(iterator.ToSlice[int](&repeatIter{42, 5}), ShouldResemble, []int{
+			42, 42, 42, 42, 42})
+	})
 
 	Convey("nxnPairs works", t, func() {
 		So(iterator.ToSlice[intPair](&nxnPairs{n: 4}), ShouldResemble, []intPair{

--- a/config/config.go
+++ b/config/config.go
@@ -484,7 +484,8 @@ type Beta struct {
 	Tickers int     `json:"tickers" default:"1"`    // #synthetic tickers
 	Samples int     `json:"samples" default:"5000"` // #synthetic prices per ticker
 	// Generate synthetic tickers with the number of log-profits given by the
-	// list.  Overrides Tickers and Samples.
+	// list.  Overrides Tickers and Samples. However, Samples is still used to
+	// generate the synthetic reference sequence; set it to max(SamplesLengths).
 	SamplesLengths []int `json:"samples lengths"`
 	// All synthetic sequences start on this day; default:"1998-01-02".
 	StartDate db.Date `json:"start date"`

--- a/config/config.go
+++ b/config/config.go
@@ -474,12 +474,18 @@ type Beta struct {
 	// Exactly one of Data or AnalyticalR must be non-nil. Each ticker in Data is
 	// analysed separately, contributing to statistics about beta and R.
 	// AnalyticalR is the distribution of R for synthetic tickers.
-	Data        *db.Reader              `json:"data"`
+	Data *db.Reader `json:"data"`
+	// Save correlated sequence lengths to file as a JSON list. The intent is to
+	// use it later in SamplesLengths.
+	LengthsFile string                  `json:"lengths file"`
 	AnalyticalR *AnalyticalDistribution `json:"analytical R"`
 	// Model P = beta * Ref + R for synthetic price series.
 	Beta    float64 `json:"beta" default:"1.0"`
 	Tickers int     `json:"tickers" default:"1"`    // #synthetic tickers
 	Samples int     `json:"samples" default:"5000"` // #synthetic prices per ticker
+	// Generate synthetic tickers with the number of log-profits given by the
+	// list.  Overrides Tickers and Samples.
+	SamplesLengths []int `json:"samples lengths"`
 	// All synthetic sequences start on this day; default:"1998-01-02".
 	StartDate db.Date `json:"start date"`
 	BatchSize int     `json:"batch size" default:"100"` // #tickers in a single job

--- a/experiments.go
+++ b/experiments.go
@@ -137,6 +137,14 @@ func PlotDistribution(ctx context.Context, dh stats.DistributionWithHistogram, c
 	if c == nil {
 		return nil
 	}
+
+	if err := AddValue(ctx, prefix, legend+" P(X < mean-10*sigma)", fmt.Sprintf("%.4g", dh.CDF(dh.Mean()-10*math.Sqrt(dh.Variance())))); err != nil {
+		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
+	}
+	if err := AddValue(ctx, prefix, legend+" P(X > mean+10*sigma)", fmt.Sprintf("%.4g", 1.0-dh.CDF(dh.Mean()+10*math.Sqrt(dh.Variance())))); err != nil {
+		return errors.Annotate(err, "failed to add value for '%s P(X > mean+10*sigma)'", legend)
+	}
+
 	var xs0 []float64
 	var ys []float64
 
@@ -150,40 +158,34 @@ func PlotDistribution(ctx context.Context, dh stats.DistributionWithHistogram, c
 	ys = h.PDFs()
 	xs, ys := filterXY(xs0, ys, c)
 	min, max := minMax(ys)
-	if err := plotDist(ctx, h, xs, ys, c, prefix, legend); err != nil {
+	prefixedLegend := Prefix(prefix, legend)
+	if err := plotDist(ctx, h, xs, ys, c, prefixedLegend); err != nil {
 		return errors.Annotate(err, "failed to plot '%s'", legend)
 	}
-	if err := plotCounts(ctx, h, xs0, c, prefix, legend); err != nil {
+	if err := plotCounts(ctx, h, xs0, c, prefixedLegend); err != nil {
 		return errors.Annotate(err, "failed to plot '%s counts'", legend)
 	}
-	if err := plotErrors(ctx, h, xs0, c, legend); err != nil {
+	if err := plotErrors(ctx, h, xs0, c, prefixedLegend); err != nil {
 		return errors.Annotate(err, "failed to plot '%s errors'", legend)
 	}
 	if c.PlotMean {
-		if err := plotMean(ctx, dh, c.Graph, min, max, legend); err != nil {
+		if err := plotMean(ctx, dh, c.Graph, min, max, prefixedLegend); err != nil {
 			return errors.Annotate(err, "failed to plot '%s mean'", legend)
 		}
 	}
-	if err := plotPercentiles(ctx, dh, c, min, max, legend); err != nil {
+	if err := plotPercentiles(ctx, dh, c, min, max, prefixedLegend); err != nil {
 		return errors.Annotate(err, "failed to plot '%s percentiles'", legend)
 	}
 	if err := plotAnalytical(ctx, dh, c, prefix, legend); err != nil {
 		return errors.Annotate(err, "failed to plot '%s ref dist'", legend)
 	}
-	if err := AddValue(ctx, prefix, legend+" P(X < mean-10*sigma)", fmt.Sprintf("%.4g", dh.CDF(dh.Mean()-10*math.Sqrt(dh.Variance())))); err != nil {
-		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
-	}
-	if err := AddValue(ctx, prefix, legend+" P(X > mean+10*sigma)", fmt.Sprintf("%.4g", 1.0-dh.CDF(dh.Mean()+10*math.Sqrt(dh.Variance())))); err != nil {
-		return errors.Annotate(err, "failed to add value for '%s P(X > mean+10*sigma)'", legend)
-	}
 	return nil
 }
 
-func plotDist(ctx context.Context, h *stats.Histogram, xs, ys []float64, c *config.DistributionPlot, prefix, legend string) error {
+func plotDist(ctx context.Context, h *stats.Histogram, xs, ys []float64, c *config.DistributionPlot, legend string) error {
 	if c.Graph == "" {
 		return nil
 	}
-	legend = Prefix(prefix, legend)
 	plt, err := plot.NewXYPlot(xs, ys)
 	if err != nil {
 		return errors.Annotate(err, "failed to create plot '%s'", legend)
@@ -204,11 +206,10 @@ func plotDist(ctx context.Context, h *stats.Histogram, xs, ys []float64, c *conf
 	return nil
 }
 
-func plotCounts(ctx context.Context, h *stats.Histogram, xs []float64, c *config.DistributionPlot, prefix, legend string) error {
+func plotCounts(ctx context.Context, h *stats.Histogram, xs []float64, c *config.DistributionPlot, legend string) error {
 	if c.CountsGraph == "" {
 		return nil
 	}
-	legend = Prefix(prefix, legend)
 	cs := make([]float64, len(h.Counts()))
 	for i, y := range h.Counts() {
 		cs[i] = float64(y)

--- a/experiments.go
+++ b/experiments.go
@@ -137,14 +137,6 @@ func PlotDistribution(ctx context.Context, dh stats.DistributionWithHistogram, c
 	if c == nil {
 		return nil
 	}
-
-	if err := AddValue(ctx, prefix, legend+" P(X < mean-10*sigma)", fmt.Sprintf("%.4g", dh.CDF(dh.Mean()-10*math.Sqrt(dh.Variance())))); err != nil {
-		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
-	}
-	if err := AddValue(ctx, prefix, legend+" P(X > mean+10*sigma)", fmt.Sprintf("%.4g", 1.0-dh.CDF(dh.Mean()+10*math.Sqrt(dh.Variance())))); err != nil {
-		return errors.Annotate(err, "failed to add value for '%s P(X > mean+10*sigma)'", legend)
-	}
-
 	var xs0 []float64
 	var ys []float64
 
@@ -178,6 +170,12 @@ func PlotDistribution(ctx context.Context, dh stats.DistributionWithHistogram, c
 	}
 	if err := plotAnalytical(ctx, dh, c, prefix, legend); err != nil {
 		return errors.Annotate(err, "failed to plot '%s ref dist'", legend)
+	}
+	if err := AddValue(ctx, prefix, legend+" P(X < mean-10*sigma)", fmt.Sprintf("%.4g", dh.CDF(dh.Mean()-10*math.Sqrt(dh.Variance())))); err != nil {
+		return errors.Annotate(err, "failed to add value for '%s P(X < mean-10*sigma)'", legend)
+	}
+	if err := AddValue(ctx, prefix, legend+" P(X > mean+10*sigma)", fmt.Sprintf("%.4g", 1.0-dh.CDF(dh.Mean()+10*math.Sqrt(dh.Variance())))); err != nil {
+		return errors.Annotate(err, "failed to add value for '%s P(X > mean+10*sigma)'", legend)
 	}
 	return nil
 }


### PR DESCRIPTION
This allows to generate synthetic data with the same set of log-profit lengths as in the real sample, and thus estimate various error margins.

Part of #93.