### PR TITLE
Generalize stability plot

### DIFF
--- a/beta/beta.go
+++ b/beta/beta.go
@@ -360,12 +360,12 @@ func (e *Beta) processLogProfits(lps []logProfits) *lpStats {
 		tss := stats.TimeseriesIntersect(lp.ts, e.refTS)
 		p := tss[0]
 		ref := tss[1]
-		stat := func(low, high int) float64 {
-			return computeBeta(p.Data()[low:high], ref.Data()[low:high])
-		}
 		if c := e.config.BetaRatios; c != nil {
+			f := func(low, high int) float64 {
+				return computeBeta(p.Data()[low:high], ref.Data()[low:high])
+			}
 			res.betaRatios = append(res.betaRatios,
-				experiments.Stability(len(p.Data()), stat, c)...)
+				experiments.Stability(len(p.Data()), f, c)...)
 		}
 		beta := computeBeta(p.Data(), ref.Data())
 		r := p.Sub(ref.MultC(beta))

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,9 @@ func (p *StabilityPlot) InitMessage(js any) error {
 	if p.Window < 1 {
 		return errors.Reason(`"window"=%d must be >= 1`, p.Window)
 	}
+	if p.Threshold < 0 {
+		return errors.Reason(`"threshold"=%f must be >= 0`, p.Threshold)
+	}
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -251,9 +251,10 @@ func TestConfig(t *testing.T) {
 						Samples:   5000,
 						StartDate: db.NewDate(1998, 1, 2),
 						BatchSize: 100,
-						BetaRatios: &TimeShiftPlot{
-							Shift:  1,
-							Window: 1,
+						BetaRatios: &StabilityPlot{
+							Step:      1,
+							Window:    1,
+							Normalize: true,
 							Plot: &DistributionPlot{
 								Graph:     "ratios",
 								Buckets:   defaultBuckets,

--- a/experiments.go
+++ b/experiments.go
@@ -721,6 +721,36 @@ func PlotScatter(ctx context.Context, xs, ys []float64, c *config.ScatterPlot, p
 	return nil
 }
 
+// Stability returns a series of deviations of the statistic f over a Timeseries
+// of size `length`, as specified by the config.
+//
+// Here f computes the statistic for the given range [low..high) (includes low,
+// excludes high).
+func Stability(length int, f func(low, high int) float64, c *config.StabilityPlot) []float64 {
+	if c == nil {
+		return nil
+	}
+	if length < c.Step+c.Window {
+		return nil
+	}
+	var norm float64 = 1
+	if c.Normalize {
+		norm = f(0, length)
+		threshold := c.Threshold
+		if threshold < 0 {
+			threshold = 0
+		}
+		if math.Abs(norm) <= threshold {
+			return nil
+		}
+	}
+	var res []float64
+	for h := length; h >= c.Window; h -= c.Step {
+		res = append(res, f(h-c.Window, h)/norm)
+	}
+	return res
+}
+
 // TestExperiment is a fake experiment used in tests. Define actual experiments
 // in their own subpackages.
 type TestExperiment struct {

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -310,6 +310,22 @@ func TestExperiments(t *testing.T) {
 			So(g.Plots[2].Y, ShouldResemble, []float64{3, 9})
 		})
 
+		Convey("Stability works", func() {
+			var cfg config.StabilityPlot
+			js := testutil.JSON(`
+{
+  "step": 2,
+  "window": 3,
+  "plot": {"graph": "g"}
+}`)
+			So(cfg.InitMessage(js), ShouldBeNil)
+			// assume ts = {0, 1, 2, 3, 4} and f = sum(ts[l]:ts[h-1]).
+			f := func(l, h int) float64 {
+				return float64(h*(h-1)/2 - l*(l-1)/2)
+			}
+			So(Stability(5, f, &cfg), ShouldResemble, []float64{0.9, 0.3})
+		})
+
 		Convey("for TestExperiment", func() {
 			conf := config.TestExperimentConfig{
 				Grade:  3.5,


### PR DESCRIPTION
Implement `config.StabilityPlot` and `experiments.Stability` to specify and compute a measure of stability of a statistic over time.

Part of #93.