### PR TITLE
Implement generic Source config and method

### DIFF
--- a/experiments.go
+++ b/experiments.go
@@ -515,11 +515,10 @@ type tsConfig struct {
 
 // generateTS generates a synthetic log-profit Timeseries.
 func generateTS(cfg tsConfig) LogProfits {
-	date := cfg.start
+	t := cfg.start.ToTime()
 	dates := make([]db.Date, cfg.n)
 	data := make([]float64, cfg.n)
 	for i := 0; i < cfg.n; i++ {
-		t := date.ToTime()
 		if t.Weekday() == time.Saturday {
 			t = t.Add(2 * 24 * time.Hour)
 		} else if t.Weekday() == time.Sunday {
@@ -528,7 +527,6 @@ func generateTS(cfg tsConfig) LogProfits {
 		dates[i] = db.NewDateFromTime(t)
 		data[i] = cfg.d.Rand()
 		t = t.Add(24 * time.Hour)
-		date = db.NewDateFromTime(t)
 	}
 	return LogProfits{
 		Ticker:     "synthetic",

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -16,9 +16,15 @@ package experiments
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stockparfait/experiments/config"
+	"github.com/stockparfait/iterator"
+	"github.com/stockparfait/stockparfait/db"
 	"github.com/stockparfait/stockparfait/plot"
 	"github.com/stockparfait/stockparfait/stats"
 	"github.com/stockparfait/testutil"
@@ -220,6 +226,108 @@ func TestExperiments(t *testing.T) {
 				d.Seed(seed)
 				So(testutil.Round(d.Mean(), 1), ShouldEqual, 10.0)
 				So(name, ShouldEqual, "Gauss x 2 x 5")
+			})
+		})
+
+		Convey("Source works", func() {
+			Convey("using synthetic", func() {
+				var cfg config.Source
+				js := testutil.JSON(`
+{
+  "synthetic": {"name": "t"},
+  "tickers": 2,
+  "samples": 10,
+  "start date": "2020-01-02"
+}`)
+				So(cfg.InitMessage(js), ShouldBeNil)
+				it, err := Source(ctx, &cfg)
+				So(err, ShouldBeNil)
+				lps := iterator.ToSlice[LogProfits](it)
+				it.Close()
+				So(len(lps), ShouldEqual, 2)
+				So(len(lps[0].Timeseries.Data()), ShouldEqual, 10)
+				So(len(lps[1].Timeseries.Data()), ShouldEqual, 10)
+				So(lps[0].Timeseries.Dates()[0], ShouldResemble, db.NewDate(2020, 1, 2))
+				So(lps[1].Timeseries.Dates()[0], ShouldResemble, db.NewDate(2020, 1, 2))
+			})
+
+			Convey("using DB, then using synthetic with saved lengths", func() {
+				tmpdir, tmpdirErr := os.MkdirTemp("", "test_autocorr")
+				defer os.RemoveAll(tmpdir)
+
+				So(tmpdirErr, ShouldBeNil)
+
+				d := func(date string) db.Date {
+					res, err := db.NewDateFromString(date)
+					if err != nil {
+						panic(err)
+					}
+					return res
+				}
+				price := func(date string, p float32) db.PriceRow {
+					return db.TestPrice(d(date), p, p, p, 1000.0, true)
+				}
+				dbName := "db"
+				tickers := map[string]db.TickerRow{
+					"A": {},
+					"B": {},
+				}
+				p0 := float32(100.0)
+				p1 := p0 * float32(math.Exp(0.01))
+				p2 := p1 * float32(math.Exp(-0.02))
+				prices := map[string][]db.PriceRow{
+					"A": {
+						price("2020-01-01", p0), // Wednesday
+						price("2020-01-02", p1),
+						price("2020-01-03", p2),
+					},
+					"B": {
+						price("2020-02-03", p0), // Monday
+						price("2020-02-04", p1),
+						price("2020-02-05", p2),
+						price("2020-02-06", p1),
+					},
+				}
+				w := db.NewWriter(tmpdir, dbName)
+				So(w.WriteTickers(tickers), ShouldBeNil)
+				for t, p := range prices {
+					So(w.WritePrices(t, p), ShouldBeNil)
+				}
+				lengthsFile := filepath.Join(tmpdir, "lengths.json")
+				var cfg config.Source
+				js := testutil.JSON(fmt.Sprintf(`
+{
+  "DB": {"DB path": "%s", "DB": "%s"},
+  "lengths file": "%s"
+}
+`, tmpdir, dbName, lengthsFile))
+				So(cfg.InitMessage(js), ShouldBeNil)
+				// Make ParallelMap deterministic.
+				ctx := iterator.TestSerialize(context.Background())
+				it, err := Source(ctx, &cfg)
+				So(err, ShouldBeNil)
+				So(len(iterator.ToSlice[LogProfits](it)), ShouldEqual, 2)
+				it.Close() // this saves lengthsFile
+				So(testutil.FileExists(lengthsFile), ShouldBeTrue)
+				// TODO: call Source for synthetic data and the same lengths file
+
+				var cfg2 config.Source
+				js2 := testutil.JSON(fmt.Sprintf(`
+{
+  "synthetic": {"name": "t"},
+  "lengths file": "%s"
+}
+`, lengthsFile))
+				So(cfg2.InitMessage(js2), ShouldBeNil)
+				it2, err := Source(ctx, &cfg2)
+				So(err, ShouldBeNil)
+				lps := iterator.ToSlice[LogProfits](it2)
+				it2.Close()
+				So(len(lps), ShouldEqual, 2)
+				So(len(lps[0].Timeseries.Data()), ShouldEqual, 2)
+				So(len(lps[1].Timeseries.Data()), ShouldEqual, 3)
+				So(lps[0].Timeseries.Dates()[0], ShouldResemble, db.NewDate(2020, 1, 2))
+				So(lps[1].Timeseries.Dates()[0], ShouldResemble, db.NewDate(2020, 2, 4))
 			})
 		})
 

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -333,8 +333,8 @@ func TestExperiments(t *testing.T) {
 				So(err, ShouldBeNil)
 				lps2 := iterator.ToSlice[LogProfits](it2)
 				it2.Close()
-				sort.Slice(lps, func(i, j int) bool {
-					return len(lps[i].Timeseries.Data()) < len(lps[j].Timeseries.Data())
+				sort.Slice(lps2, func(i, j int) bool {
+					return len(lps2[i].Timeseries.Data()) < len(lps2[j].Timeseries.Data())
 				})
 				So(len(lps2), ShouldEqual, 2)
 				So(len(lps2[0].Timeseries.Data()), ShouldEqual, 2)

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require (
 	github.com/smartystreets/goconvey v1.7.2
 	github.com/stockparfait/errors v0.2.0
-	github.com/stockparfait/iterator v0.1.5
+	github.com/stockparfait/iterator v0.1.7
 	github.com/stockparfait/logging v0.2.0
-	github.com/stockparfait/stockparfait v0.3.0
+	github.com/stockparfait/stockparfait v0.3.1
 	github.com/stockparfait/testutil v0.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,12 +8,12 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/stockparfait/errors v0.2.0 h1:LQSUrh+bFz+lXaQRIS+0U+Hbrwo+Zmnx6m3nSmApGMA=
 github.com/stockparfait/errors v0.2.0/go.mod h1:tQW05CIhDc776OHjHzIHtmsK3FRCTviij+S06R0sgIY=
-github.com/stockparfait/iterator v0.1.5 h1:JDYBmJZAQdrzMlys6WKv9HHxsigDoy6E5zQT5u9//H4=
-github.com/stockparfait/iterator v0.1.5/go.mod h1:8EdJTJXxLDOOCYKAWi3c28Ajl7jJgzYxUAmwkuREVuc=
+github.com/stockparfait/iterator v0.1.7 h1:F0BCBUN7l/ZNIV6YlhQzWN89naJPJoGqnoaJpg2q9Ks=
+github.com/stockparfait/iterator v0.1.7/go.mod h1:8EdJTJXxLDOOCYKAWi3c28Ajl7jJgzYxUAmwkuREVuc=
 github.com/stockparfait/logging v0.2.0 h1:KTRNyL2bK5Edopj51uDY9eth0K7VfqrFjz0948OtdH8=
 github.com/stockparfait/logging v0.2.0/go.mod h1:nvvnmIwvQ4Vktsnxjvvw5v72S4OYwyUD81KYPuXZH1o=
-github.com/stockparfait/stockparfait v0.3.0 h1:7T0Q+5OpZXziuH1i9HAquLVM8QXELyLS7iLhvdxy95g=
-github.com/stockparfait/stockparfait v0.3.0/go.mod h1:1cGnTQ7IoltXeU07Ucvhdh8SffUOXQs0iZa8jrPbCRw=
+github.com/stockparfait/stockparfait v0.3.1 h1:brr+K5MqVCAH8cqucKaymM6FFPjPSFkuV5F3ZNGuf6c=
+github.com/stockparfait/stockparfait v0.3.1/go.mod h1:UvOutRV/faZxkdLahIqMVh7BUK0KQHgxa1rtvI9vVDo=
 github.com/stockparfait/testutil v0.2.0 h1:kxs5zVNM6N4tEO0jAA99LHxK1a0ueK6/bCJAjv59Z3I=
 github.com/stockparfait/testutil v0.2.0/go.mod h1:tDwaH6tBI0cATzjaNpGI37TXhqLpIYtuM8aWJyz1ktM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
This allows to instantiate either real prices from DB or generate synthetic ones under a single API, and reuse the same experiment flow to process both.

Part of #108.