### PR TITLE
Add batching to Source, implement SourceMap

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -221,7 +221,8 @@ type Source struct {
 	// All synthetic sequences start on this day; default:"1998-01-02".
 	StartDate db.Date `json:"start date"`
 	// Parallel processing parameters.
-	Workers int `json:"workers"` // default: 2*runtime.NumCPU()
+	Workers   int `json:"workers"` // default: 2*runtime.NumCPU()
+	BatchSize int `json:"batch size" default:"10"`
 }
 
 func (s *Source) InitMessage(js any) error {

--- a/config/config.go
+++ b/config/config.go
@@ -221,8 +221,8 @@ type Source struct {
 	// All synthetic sequences start on this day; default:"1998-01-02".
 	StartDate db.Date `json:"start date"`
 	// Parallel processing parameters.
-	Workers   int `json:"workers"` // default: 2*runtime.NumCPU()
-	BatchSize int `json:"batch size" default:"10"`
+	Workers   int `json:"workers"`                 // default: 2*runtime.NumCPU()
+	BatchSize int `json:"batch size" default:"10"` // must be >= 1
 }
 
 func (s *Source) InitMessage(js any) error {
@@ -237,6 +237,9 @@ func (s *Source) InitMessage(js any) error {
 	}
 	if s.Workers <= 0 {
 		s.Workers = 2 * runtime.NumCPU()
+	}
+	if s.BatchSize < 1 {
+		return errors.Reason(`"batch size"=%d must be >= 1`, s.BatchSize)
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -250,6 +250,7 @@ func TestConfig(t *testing.T) {
 							Samples:   5000,
 							StartDate: db.NewDate(1998, 1, 2),
 							Workers:   1,
+							BatchSize: 10,
 						},
 						Data: &Source{
 							DB:        &defaultReader,
@@ -257,6 +258,7 @@ func TestConfig(t *testing.T) {
 							Samples:   5000,
 							StartDate: db.NewDate(1998, 1, 2),
 							Workers:   1,
+							BatchSize: 10,
 						},
 						Beta:      1,
 						BatchSize: 100,

--- a/experiments.go
+++ b/experiments.go
@@ -491,10 +491,7 @@ func sourceDB[T any](ctx context.Context, c *config.Source, f func(LogProfits) T
 			if c.Length > 0 {
 				c.Start = ts.Dates()[0]
 			}
-			res[i] = withConf[T]{
-				v: v,
-				c: c,
-			}
+			res[i] = withConf[T]{v: v, c: c}
 		}
 		return res
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/smartystreets/goconvey v1.7.2
 	github.com/stockparfait/errors v0.2.0
-	github.com/stockparfait/iterator v0.1.7
+	github.com/stockparfait/iterator v0.1.8
 	github.com/stockparfait/logging v0.2.0
 	github.com/stockparfait/stockparfait v0.3.1
 	github.com/stockparfait/testutil v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/stockparfait/errors v0.2.0 h1:LQSUrh+bFz+lXaQRIS+0U+Hbrwo+Zmnx6m3nSmApGMA=
 github.com/stockparfait/errors v0.2.0/go.mod h1:tQW05CIhDc776OHjHzIHtmsK3FRCTviij+S06R0sgIY=
-github.com/stockparfait/iterator v0.1.7 h1:F0BCBUN7l/ZNIV6YlhQzWN89naJPJoGqnoaJpg2q9Ks=
-github.com/stockparfait/iterator v0.1.7/go.mod h1:8EdJTJXxLDOOCYKAWi3c28Ajl7jJgzYxUAmwkuREVuc=
+github.com/stockparfait/iterator v0.1.8 h1:CMlTVwMOfvexMjKF4WfrW6boOXmqgoupjdNA0/0RRYs=
+github.com/stockparfait/iterator v0.1.8/go.mod h1:8EdJTJXxLDOOCYKAWi3c28Ajl7jJgzYxUAmwkuREVuc=
 github.com/stockparfait/logging v0.2.0 h1:KTRNyL2bK5Edopj51uDY9eth0K7VfqrFjz0948OtdH8=
 github.com/stockparfait/logging v0.2.0/go.mod h1:nvvnmIwvQ4Vktsnxjvvw5v72S4OYwyUD81KYPuXZH1o=
 github.com/stockparfait/stockparfait v0.3.1 h1:brr+K5MqVCAH8cqucKaymM6FFPjPSFkuV5F3ZNGuf6c=


### PR DESCRIPTION
`SourceMap` should improve the efficiency of parallelization by reducing inter-process communications and calling the user-supplied callback in the same parallel worker.

Part of #108.