### PR TITLE
SourceMap: apply callback to batches of LogProfits

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go 1.19
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out code

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ section for details on how to use such configs with the tool.
 ## Installation
 
 Requirements:
-- [Google Go](https://go.dev/dl/) 1.18 or higher;
+- [Google Go](https://go.dev/dl/) 1.19 or higher;
 - `parfait-sharadar` app to download data; see [stockparfait/stockparfait] for
   installation instructions;
 - Subscription to Sharadar Equities Prices on [Nasdaq Data Link]

--- a/beta/beta.go
+++ b/beta/beta.go
@@ -78,9 +78,6 @@ func (e *Beta) processReference(ctx context.Context) error {
 			"reference should yield exactly one series, got %d", len(lps))
 	}
 	lp := lps[0]
-	if lp.Error != nil {
-		return errors.Annotate(err, "failed to get reference price series")
-	}
 	e.refTS = lp.Timeseries
 	return nil
 }
@@ -96,9 +93,6 @@ func (e *Beta) processData(ctx context.Context) error {
 	f := func(lps []experiments.LogProfits) *lpStats {
 		if e.config.Data.Synthetic != nil { // treat lps as R
 			for i, lp := range lps {
-				if lp.Error != nil {
-					continue // skip it, the error will be handled later
-				}
 				tss := stats.TimeseriesIntersect(e.refTS, lp.Timeseries)
 				lp.Timeseries = tss[0].MultC(e.config.Beta).Add(tss[1])
 				lps[i] = lp
@@ -221,10 +215,6 @@ func (e *Beta) processLogProfits(ctx context.Context, lps []experiments.LogProfi
 		res.histR = stats.NewHistogram(&e.config.RPlot.Buckets)
 	}
 	for _, lp := range lps {
-		if lp.Error != nil {
-			logging.Warningf(ctx, "skipping %s: %s", lp.Ticker, lp.Error.Error())
-			continue
-		}
 		tss := stats.TimeseriesIntersect(lp.Timeseries, e.refTS)
 		p := tss[0]
 		ref := tss[1]

--- a/experiments.go
+++ b/experiments.go
@@ -461,7 +461,6 @@ func readLengths(fileName string) ([]synthConfig, error) {
 type LogProfits struct {
 	Ticker     string
 	Timeseries *stats.Timeseries
-	Error      error
 }
 
 type withConf[T any] struct {

--- a/experiments.go
+++ b/experiments.go
@@ -598,7 +598,7 @@ func sourceSynthetic[T any](ctx context.Context, c *config.Source, f func([]LogP
 // Source generates log-profit sequence according to the config. Please remember
 // to close the resulting iterator.
 func Source(ctx context.Context, c *config.Source) (iterator.IteratorCloser[LogProfits], error) {
-	sm, err := SourceMap(ctx, c, func(l []LogProfits) []LogProfits { return l })
+	sm, err := SourceMap[[]LogProfits](ctx, c, func(l []LogProfits) []LogProfits { return l })
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to generate log-profits")
 	}

--- a/experiments.go
+++ b/experiments.go
@@ -598,7 +598,7 @@ func sourceSynthetic[T any](ctx context.Context, c *config.Source, f func([]LogP
 // Source generates log-profit sequence according to the config. Please remember
 // to close the resulting iterator.
 func Source(ctx context.Context, c *config.Source) (iterator.IteratorCloser[LogProfits], error) {
-	sm, err := SourceMap[[]LogProfits](ctx, c, func(l []LogProfits) []LogProfits { return l })
+	sm, err := SourceMap(ctx, c, func(l []LogProfits) []LogProfits { return l })
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to generate log-profits")
 	}

--- a/experiments.go
+++ b/experiments.go
@@ -465,35 +465,35 @@ type LogProfits struct {
 }
 
 type withConf[T any] struct {
-	v T
-	c synthConfig
+	v  T
+	cs []synthConfig
 }
 
-func sourceDB[T any](ctx context.Context, c *config.Source, f func(LogProfits) T) (iterator.IteratorCloser[T], error) {
+func sourceDB[T any](ctx context.Context, c *config.Source, f func([]LogProfits) T) (iterator.IteratorCloser[T], error) {
 	if c.DB == nil {
 		return nil, errors.Reason("DB must not be nil")
 	}
-	mapF := func(tickers []string) []withConf[T] {
-		res := make([]withConf[T], len(tickers))
+	mapF := func(tickers []string) withConf[T] {
+		cs := make([]synthConfig, len(tickers))
+		lps := make([]LogProfits, len(tickers))
 		for i, ticker := range tickers {
 			rows, err := c.DB.Prices(ticker)
 			if err != nil {
-				res[i] = withConf[T]{
-					v: f(LogProfits{
-						Error: errors.Annotate(err, "failed to read prices for %s", ticker),
-					}),
+				lps[i] = LogProfits{
+					Error: errors.Annotate(err, "failed to read prices for %s", ticker),
 				}
 				continue
 			}
-			ts := stats.NewTimeseriesFromPrices(rows, stats.PriceFullyAdjusted).LogProfits(1)
-			v := f(LogProfits{Ticker: ticker, Timeseries: ts})
-			c := synthConfig{Length: len(ts.Data())}
-			if c.Length > 0 {
-				c.Start = ts.Dates()[0]
+			lps[i] = LogProfits{
+				Ticker:     ticker,
+				Timeseries: stats.NewTimeseriesFromPrices(rows, stats.PriceFullyAdjusted).LogProfits(1),
 			}
-			res[i] = withConf[T]{v: v, c: c}
+			cs[i] = synthConfig{Length: len(lps[i].Timeseries.Data())}
+			if cs[i].Length > 0 {
+				cs[i].Start = lps[i].Timeseries.Dates()[0]
+			}
 		}
-		return res
+		return withConf[T]{v: f(lps), cs: cs}
 	}
 	tickers, err := c.DB.Tickers(ctx)
 	if err != nil {
@@ -501,15 +501,16 @@ func sourceDB[T any](ctx context.Context, c *config.Source, f func(LogProfits) T
 	}
 	batchIt := iterator.Batch[string](iterator.FromSlice(tickers), c.BatchSize)
 	pm := iterator.ParallelMap(ctx, c.Workers, batchIt, mapF)
-	unbatchIt := iterator.Unbatch[withConf[T]](pm)
 	var cs []synthConfig
 	addLength := func(vc withConf[T]) T {
-		if vc.c.Length > 0 {
-			cs = append(cs, vc.c)
+		for _, c := range vc.cs {
+			if c.Length > 0 {
+				cs = append(cs, c)
+			}
 		}
 		return vc.v
 	}
-	it := iterator.WithClose(iterator.Map[withConf[T], T](unbatchIt, addLength), func() {
+	it := iterator.WithClose(iterator.Map[withConf[T], T](pm, addLength), func() {
 		pm.Close()
 		if err := saveLengths(cs, c.LengthsFile); err != nil {
 			logging.Warningf(ctx, "failed to save lengths file: %s", err.Error())
@@ -564,7 +565,7 @@ func (it *distIter) Next() (tsConfig, bool) {
 	return tsConfig{d: it.d.Copy(), start: c.Start, n: c.Length}, true
 }
 
-func sourceSynthetic[T any](ctx context.Context, c *config.Source, f func(LogProfits) T) (iterator.IteratorCloser[T], error) {
+func sourceSynthetic[T any](ctx context.Context, c *config.Source, f func([]LogProfits) T) (iterator.IteratorCloser[T], error) {
 	d, _, err := AnalyticalDistribution(ctx, c.Synthetic)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to create synthetic distribution")
@@ -582,32 +583,36 @@ func sourceSynthetic[T any](ctx context.Context, c *config.Source, f func(LogPro
 	}
 	distIt := &distIter{d: d, lengthsIter: lengthsIter}
 	batchIt := iterator.Batch[tsConfig](distIt, c.BatchSize)
-	pf := func(cs []tsConfig) []T {
-		res := make([]T, len(cs))
+	pf := func(cs []tsConfig) T {
+		lps := make([]LogProfits, len(cs))
 		for i, c := range cs {
-			res[i] = f(generateTS(c))
+			lps[i] = generateTS(c)
 		}
-		return res
+		return f(lps)
 	}
-	pm := iterator.ParallelMap[[]tsConfig, []T](ctx, c.Workers, batchIt, pf)
-	it := iterator.WithClose(iterator.Unbatch[T](pm), func() { pm.Close() })
-	return it, nil
+	pm := iterator.ParallelMap[[]tsConfig, T](ctx, c.Workers, batchIt, pf)
+	return pm, nil
 }
 
 // Source generates log-profit sequence according to the config. Please remember
 // to close the resulting iterator.
 func Source(ctx context.Context, c *config.Source) (iterator.IteratorCloser[LogProfits], error) {
-	return SourceMap[LogProfits](ctx, c, func(l LogProfits) LogProfits { return l })
+	sm, err := SourceMap(ctx, c, func(l []LogProfits) []LogProfits { return l })
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to generate log-profits")
+	}
+	it := iterator.Unbatch[LogProfits](sm)
+	return iterator.WithClose(it, func() { sm.Close() }), nil
 }
 
-// SourceMap generates log-profit sequence according to the config, processes
-// them with f and returns an iterator of f(LogProfits). The advantage over
-// Source() followed by Map or ParallelMap is that f() is called in the same
-// parallel worker that processes each ticker, thus reducing inter-process
-// communications.
+// SourceMap generates log-profit sequences according to the config, processes
+// them with f in batches and returns an iterator of f([]LogProfits). The
+// advantage over Source() followed by Map or ParallelMap is that f() is called
+// in the same parallel worker that processes each batch of tickers, thus
+// reducing inter-process communications.
 //
 // Please remember to close the resulting iterator.
-func SourceMap[T any](ctx context.Context, c *config.Source, f func(LogProfits) T) (iterator.IteratorCloser[T], error) {
+func SourceMap[T any](ctx context.Context, c *config.Source, f func([]LogProfits) T) (iterator.IteratorCloser[T], error) {
 	switch {
 	case c.DB != nil:
 		return sourceDB[T](ctx, c, f)


### PR DESCRIPTION
The user callback is often more efficient when applied to a batch of tickers / log-profit sequences. Update `SourceMap` API to accommodate that.

Part of #108.