### PR TITLE
Trading: add a threshold for close/open distribution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -606,6 +606,8 @@ type Trading struct {
 	// Log-profits of high and close relative to the same day open.
 	HighOpenPlot  *DistributionPlot `json:"high/open plot"`
 	CloseOpenPlot *DistributionPlot `json:"close/open plot"`
+	// Optional threshold T to condition close/open distribution by high/open < T.
+	Threshold *float64 `json:"threshold"`
 	// Log-profits of OHLC relative to the previous Close.
 	OpenPlot  *DistributionPlot `json:"open plot"`
 	HighPlot  *DistributionPlot `json:"high plot"`


### PR DESCRIPTION
This allows plotting the distribution of `close/open` conditioned on `high/open` being below the threshold. This, in turn, models a strategy of buying at `open`, selling at the target price (the threshold), and if the target is not reached, sell at `close`.

Part of #116.