### PR TITLE
Generate OHL prices using intraday samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all:
 
 init:
 	go install github.com/smartystreets/goconvey@v1.7.2
-	go install honnef.co/go/tools/cmd/staticcheck@2023.1.2
+	go install honnef.co/go/tools/cmd/staticcheck@2023.1.3
 	go install github.com/sergey-a-berezin/gocovcheck@v1.3.0
 	go install github.com/sergey-a-berezin/gocovcheck/jsonread@v1.3.0
 	@echo "Bootstrap done!"

--- a/autocorr/assets/synthetic-25M.json
+++ b/autocorr/assets/synthetic-25M.json
@@ -3,7 +3,7 @@
     {
       "auto-correlation": {
         "data": {
-          "close": {
+          "daily distribution": {
             "name": "t"
           },
           "samples": 25000000

--- a/autocorr/assets/synthetic-25M.json
+++ b/autocorr/assets/synthetic-25M.json
@@ -6,7 +6,7 @@
           "daily distribution": {
             "name": "t"
           },
-          "samples": 25000000
+          "days": 25000000
         },
         "graph": "corr",
         "id": "synthetic 25000000 samples",

--- a/autocorr/assets/synthetic-6K.json
+++ b/autocorr/assets/synthetic-6K.json
@@ -3,7 +3,7 @@
     {
       "auto-correlation": {
         "data": {
-          "close": {
+          "daily distribution": {
             "name": "t"
           },
           "samples": 6000
@@ -21,9 +21,11 @@
             "cash volume": {
               "min": 1000000
             },
+            "end": "2022-07-31",
             "sources": [
               "SEP"
-            ]
+            ],
+            "start": "1998-01-01"
           }
         },
         "graph": "corr",

--- a/autocorr/assets/synthetic-6K.json
+++ b/autocorr/assets/synthetic-6K.json
@@ -6,7 +6,7 @@
           "daily distribution": {
             "name": "t"
           },
-          "samples": 6000
+          "days": 6000
         },
         "graph": "corr",
         "id": "synthetic 6000 samples",

--- a/autocorr/autocorr_test.go
+++ b/autocorr/autocorr_test.go
@@ -105,7 +105,7 @@ func TestAutoCorrelation(t *testing.T) {
 {
   "id": "testID",
   "data": {
-    "close": {"name": "t"},
+    "daily distribution": {"name": "t"},
     "samples": 150,
     "batch size": 100
   },

--- a/autocorr/autocorr_test.go
+++ b/autocorr/autocorr_test.go
@@ -106,7 +106,7 @@ func TestAutoCorrelation(t *testing.T) {
   "id": "testID",
   "data": {
     "daily distribution": {"name": "t"},
-    "samples": 150,
+    "days": 150,
     "batch size": 100
   },
   "graph": "g",

--- a/beta/beta.go
+++ b/beta/beta.go
@@ -84,7 +84,7 @@ func (e *Beta) processReference(ctx context.Context) error {
 
 func (e *Beta) processData(ctx context.Context) error {
 	f := func(lps []experiments.LogProfits) *lpStats {
-		if e.config.Data.Close != nil { // treat lps as R
+		if e.config.Data.DailyDist != nil { // treat lps as R
 			for i, lp := range lps {
 				tss := stats.TimeseriesIntersect(e.refTS, lp.Timeseries)
 				lp.Timeseries = tss[0].MultC(e.config.Beta).Add(tss[1])

--- a/beta/beta_test.go
+++ b/beta/beta_test.go
@@ -169,14 +169,11 @@ func TestBeta(t *testing.T) {
 			confJSON := fmt.Sprintf(`
 {
   "id": "testID",
-  "reference": {
-    "daily distribution": {"name": "t"},
-    "samples": 10
-  },
+  "reference": {"daily distribution": {"name": "t"}, "days": 10},
   "data": {
     "daily distribution": {"name": "t"},
     "tickers": 3,
-    "samples": 10
+    "days": 10
   },
   "file": "%s",
   "beta plot": {"graph": "beta"},

--- a/beta/beta_test.go
+++ b/beta/beta_test.go
@@ -169,9 +169,12 @@ func TestBeta(t *testing.T) {
 			confJSON := fmt.Sprintf(`
 {
   "id": "testID",
-  "reference": {"close": {"name": "t"}, "samples": 10},
+  "reference": {
+    "daily distribution": {"name": "t"},
+    "samples": 10
+  },
   "data": {
-    "close": {"name": "t"},
+    "daily distribution": {"name": "t"},
     "tickers": 3,
     "samples": 10
   },

--- a/config/config.go
+++ b/config/config.go
@@ -218,15 +218,15 @@ type Source struct {
 	DailyDist *AnalyticalDistribution `json:"daily distribution"`
 	// Skip log-profits that span two days.
 	IntradayOnly bool `json:"intraday only"`
-	// Required for generating OHL prices or intraday series.
+	// Required for generating OHLC prices or intraday series.
 	IntradayDist *AnalyticalDistribution `json:"intraday distribution"`
 	// Default: 9:30am - 4pm.
 	IntradayRange *db.IntradayRange `json:"intraday range"`
 	// Resolution of the intraday samples in minutes: 1, 5, 15 or 30.
 	IntradayRes int `json:"intraday resolution" default:"1"`
 	// With DB, saves the start date and the number of days for each ticker as a
-	// JSON file.  With Synthetic, read this file and generate synthetic tickers
-	// accordingly, overwriting the other parameters.
+	// JSON file.  With synthetic distributions, read this file and generate
+	// synthetic tickers accordingly, overwriting the other parameters.
 	LengthsFile string `json:"lengths file"`
 	// Amount of synthetic data to generate. Note, that with intraday
 	// distribution, the number of samples is N*days where N is the number of

--- a/config/config.go
+++ b/config/config.go
@@ -209,17 +209,18 @@ func (d *CompoundDistribution) InitMessage(js any) error {
 // Source is a generic config for a set of price series that come either from
 // the actual price database or synthetically generated.
 type Source struct {
-	// Exactly one of DB or Close must be non-nil.
-	DB       *db.Reader `json:"DB"`
-	Intraday bool       `json:"intraday"` // skip log-profits that span two days.
-	Compound int        `json:"compound" default:"1"`
-	// Log-profit distributions for OHL prices relative to the previous close. By
-	// default they reuse the same closing price value, with high and low prices
-	// adjusted to include open and close in [low..high] range.
-	Open  *AnalyticalDistribution `json:"open"`
-	High  *AnalyticalDistribution `json:"high"`
-	Low   *AnalyticalDistribution `json:"low"`
-	Close *AnalyticalDistribution `json:"close"`
+	// Exactly one of DB or DailyDist must be non-nil.
+	DB        *db.Reader              `json:"DB"`
+	Compound  int                     `json:"compound" default:"1"`
+	DailyDist *AnalyticalDistribution `json:"daily distribution"`
+	// Skip log-profits that span two days.
+	Intraday bool `json:"intraday"`
+	// Required for generating OHL prices or intraday series.
+	IntradayDist *AnalyticalDistribution `json:"intraday distribution"`
+	// Default: 9:30am - 4pm.
+	IntradayRange *db.IntradayRange `json:"intraday range"`
+	// Resolution of the intraday samples in minutes: 1, 5, 15 or 30.
+	IntradayRes int `json:"intraday resolution" default:"1"`
 	// With DB, saves the start date and the number of samples for each ticker as
 	// a JSON file.  With Synthetic, read this file and generate synthetic tickers
 	// accordingly, overwriting the other parameters.
@@ -237,8 +238,28 @@ func (s *Source) InitMessage(js any) error {
 	if err := message.Init(s, js); err != nil {
 		return errors.Annotate(err, "failed to init Source")
 	}
-	if (s.DB == nil) == (s.Close == nil) {
-		return errors.Reason(`expected exactly one of "DB" or "synthetic"`)
+	if (s.DB == nil) == (s.DailyDist == nil) {
+		return errors.Reason(`expected exactly one of "DB" or "%s"`,
+			"daily distribution")
+	}
+	if s.IntradayRange == nil {
+		start := db.NewTimeOfDay(9, 30, 0, 0)
+		end := db.NewTimeOfDay(16, 0, 0, 0)
+		s.IntradayRange = &db.IntradayRange{
+			Start: &start,
+			End:   &end,
+		}
+	}
+	intradayResValid := false
+	for _, v := range []int{1, 5, 15, 30} {
+		if s.IntradayRes == v {
+			intradayResValid = true
+			break
+		}
+	}
+	if !intradayResValid {
+		return errors.Reason(`"intraday resolution"=%d must be 1, 5, 15 or 30`,
+			s.IntradayRes)
 	}
 	if s.StartDate.IsZero() {
 		s.StartDate = db.NewDate(1998, 1, 2)

--- a/config/config.go
+++ b/config/config.go
@@ -209,24 +209,30 @@ func (d *CompoundDistribution) InitMessage(js any) error {
 // Source is a generic config for a set of price series that come either from
 // the actual price database or synthetically generated.
 type Source struct {
-	// Exactly one of DB or DailyDist must be non-nil.
-	DB        *db.Reader              `json:"DB"`
-	Compound  int                     `json:"compound" default:"1"`
+	// Real price series database. When present, no synthetic distribution is
+	// allowed.
+	DB       *db.Reader `json:"DB"`
+	Compound int        `json:"compound" default:"1"`
+	// Log-profit distribution for close[t]/close[t-1] by default, or
+	// open[t+1]/close[t] when intraday distribution is present.
 	DailyDist *AnalyticalDistribution `json:"daily distribution"`
 	// Skip log-profits that span two days.
-	Intraday bool `json:"intraday"`
+	IntradayOnly bool `json:"intraday only"`
 	// Required for generating OHL prices or intraday series.
 	IntradayDist *AnalyticalDistribution `json:"intraday distribution"`
 	// Default: 9:30am - 4pm.
 	IntradayRange *db.IntradayRange `json:"intraday range"`
 	// Resolution of the intraday samples in minutes: 1, 5, 15 or 30.
 	IntradayRes int `json:"intraday resolution" default:"1"`
-	// With DB, saves the start date and the number of samples for each ticker as
-	// a JSON file.  With Synthetic, read this file and generate synthetic tickers
+	// With DB, saves the start date and the number of days for each ticker as a
+	// JSON file.  With Synthetic, read this file and generate synthetic tickers
 	// accordingly, overwriting the other parameters.
 	LengthsFile string `json:"lengths file"`
-	Tickers     int    `json:"tickers" default:"1"`    // #synthetic tickers
-	Samples     int    `json:"samples" default:"5000"` // #synthetic prices per ticker
+	// Amount of synthetic data to generate. Note, that with intraday
+	// distribution, the number of samples is N*days where N is the number of
+	// intraday samples.
+	Tickers int `json:"tickers" default:"1"` // #synthetic tickers
+	Days    int `json:"days" default:"5000"` // #synthetic days per ticker
 	// All synthetic sequences start on this day; default:"1998-01-02".
 	StartDate db.Date `json:"start date"`
 	// Parallel processing parameters.
@@ -238,9 +244,13 @@ func (s *Source) InitMessage(js any) error {
 	if err := message.Init(s, js); err != nil {
 		return errors.Annotate(err, "failed to init Source")
 	}
-	if (s.DB == nil) == (s.DailyDist == nil) {
-		return errors.Reason(`expected exactly one of "DB" or "%s"`,
-			"daily distribution")
+	if s.DB != nil {
+		if s.DailyDist != nil {
+			return errors.Reason(`cannot have both "DB" and "daily distribution"`)
+		}
+		if s.IntradayDist != nil {
+			return errors.Reason(`cannot have both "DB" and "intraday distribution"`)
+		}
 	}
 	if s.IntradayRange == nil {
 		start := db.NewTimeOfDay(9, 30, 0, 0)
@@ -554,10 +564,6 @@ func (e *AutoCorrelation) InitMessage(js any) error {
 	}
 	if e.MaxShift <= 0 {
 		return errors.Reason("max shift = %d must be >= 1", e.MaxShift)
-	}
-	if e.Data.Samples <= e.MaxShift+2 {
-		return errors.Reason("data[samples]=%d must be >= max shift+2 = %d",
-			e.Data.Samples, e.MaxShift+2)
 	}
 	return nil
 }

--- a/experiments.go
+++ b/experiments.go
@@ -813,7 +813,7 @@ func sourceSyntheticPrices[T any](ctx context.Context, c *config.Source, f func(
 	pf := func(cs []tsConfig) T {
 		var prices []Prices
 		for _, c := range cs {
-			if c.days < 1 { // n = number of raw prices, need at least 1
+			if c.days < 1 {
 				continue
 			}
 			prices = append(prices, generatePrices(c))

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -242,7 +242,31 @@ func TestExperiments(t *testing.T) {
 				return db.TestPrice(d(date), p, p, p, 1000.0, true)
 			}
 
-			Convey("using synthetic", func() {
+			Convey("using synthetic daily", func() {
+				var cfg config.Source
+				js := testutil.JSON(`
+{
+  "daily distribution": {"name": "t"},
+  "tickers": 2,
+  "days": 11,
+  "batch size": 1,
+  "start date": "2020-01-02"
+}`)
+				So(cfg.InitMessage(js), ShouldBeNil)
+
+				it, err := Source(ctx, &cfg)
+				So(err, ShouldBeNil)
+				lps := iterator.ToSlice[LogProfits](it)
+				it.Close()
+				So(len(lps), ShouldEqual, 2)
+				// Log-profits start one day after the first price.
+				So(len(lps[0].Timeseries.Data()), ShouldEqual, 10)
+				So(len(lps[1].Timeseries.Data()), ShouldEqual, 10)
+				So(lps[0].Timeseries.Dates()[0], ShouldResemble, d("2020-01-03"))
+				So(lps[1].Timeseries.Dates()[0], ShouldResemble, d("2020-01-03"))
+			})
+
+			Convey("using synthetic intraday", func() {
 				var cfg config.Source
 				// Keep the number of intraday samples small for efficiency.
 				js := testutil.JSON(`
@@ -252,23 +276,43 @@ func TestExperiments(t *testing.T) {
   "intraday resolution": 30,
   "intraday range": {"start": "12:00", "end": "13:00"},
   "tickers": 2,
-  "samples": 11,
+  "days": 11,
   "batch size": 1,
   "start date": "2020-01-02"
 }`)
 				So(cfg.InitMessage(js), ShouldBeNil)
 
-				Convey("LogProfits only", func() {
+				Convey("All LogProfits", func() {
 					it, err := Source(ctx, &cfg)
 					So(err, ShouldBeNil)
 					lps := iterator.ToSlice[LogProfits](it)
 					it.Close()
 					So(len(lps), ShouldEqual, 2)
-					// Log-profits start one day after the first price.
-					So(len(lps[0].Timeseries.Data()), ShouldEqual, 10)
-					So(len(lps[1].Timeseries.Data()), ShouldEqual, 10)
-					So(lps[0].Timeseries.Dates()[0], ShouldResemble, d("2020-01-03"))
-					So(lps[1].Timeseries.Dates()[0], ShouldResemble, d("2020-01-03"))
+					// 2 intraday samples + 1 inter-day per day, minus spurious one at the
+					// start, total = 11*3 - 1 = 32.
+					So(len(lps[0].Timeseries.Data()), ShouldEqual, 32)
+					So(len(lps[1].Timeseries.Data()), ShouldEqual, 32)
+					So(lps[0].Timeseries.Dates()[0], ShouldResemble,
+						db.NewDatetime(2020, 1, 2, 12, 30, 0, 0))
+					So(lps[1].Timeseries.Dates()[0], ShouldResemble,
+						db.NewDatetime(2020, 1, 2, 12, 30, 0, 0))
+				})
+
+				Convey("Intraday LogProfits only", func() {
+					c := cfg // local copy
+					c.IntradayOnly = true
+					it, err := Source(ctx, &c)
+					So(err, ShouldBeNil)
+					lps := iterator.ToSlice[LogProfits](it)
+					it.Close()
+					So(len(lps), ShouldEqual, 2)
+					// 2 intraday samples per day.
+					So(len(lps[0].Timeseries.Data()), ShouldEqual, 22)
+					So(len(lps[1].Timeseries.Data()), ShouldEqual, 22)
+					So(lps[0].Timeseries.Dates()[0], ShouldResemble,
+						db.NewDatetime(2020, 1, 2, 12, 30, 0, 0))
+					So(lps[1].Timeseries.Dates()[0], ShouldResemble,
+						db.NewDatetime(2020, 1, 2, 12, 30, 0, 0))
 				})
 
 				Convey("OHLC prices", func() {
@@ -351,9 +395,6 @@ func TestExperiments(t *testing.T) {
 				js2 := testutil.JSON(fmt.Sprintf(`
 {
   "daily distribution": {"name": "t"},
-  "intraday distribution": {"name": "t"},
-  "intraday resolution": 30,
-  "intraday range": {"start": "12:00", "end": "13:00"},
   "lengths file": "%s"
 }
 `, lengthsFile))

--- a/experiments_test.go
+++ b/experiments_test.go
@@ -244,12 +244,13 @@ func TestExperiments(t *testing.T) {
 
 			Convey("using synthetic", func() {
 				var cfg config.Source
+				// Keep the number of intraday samples small for efficiency.
 				js := testutil.JSON(`
 {
-  "open": {"name": "t"},
-  "high": {"name": "t"},
-  "low": {"name": "t"},
-  "close": {"name": "t"},
+  "daily distribution": {"name": "t"},
+  "intraday distribution": {"name": "t"},
+  "intraday resolution": 30,
+  "intraday range": {"start": "12:00", "end": "13:00"},
   "tickers": 2,
   "samples": 11,
   "batch size": 1,
@@ -349,7 +350,10 @@ func TestExperiments(t *testing.T) {
 				var cfg2 config.Source
 				js2 := testutil.JSON(fmt.Sprintf(`
 {
-  "close": {"name": "t"},
+  "daily distribution": {"name": "t"},
+  "intraday distribution": {"name": "t"},
+  "intraday resolution": 30,
+  "intraday range": {"start": "12:00", "end": "13:00"},
   "lengths file": "%s"
 }
 `, lengthsFile))


### PR DESCRIPTION
Previously, I tried to model `open`, `high` and `low` prices as a log-profit distribution relative to the previous `close`. However, this doesn't really make sense. A much more realistic model is to introduce a separate distribution for high frequency intraday samples (default 1 min) and derive OHL from those.

Part of  #130 
Part of #116 